### PR TITLE
WIP: Expose change streams from Buffer and Editor

### DIFF
--- a/xray_core/Cargo.toml
+++ b/xray_core/Cargo.toml
@@ -5,3 +5,5 @@ authors = ["Nathan Sobo <nathan@github.com>"]
 
 [dependencies]
 rand = "0.3"
+multiqueue = "0.3"
+futures = "0.1"

--- a/xray_core/src/lib.rs
+++ b/xray_core/src/lib.rs
@@ -1,8 +1,11 @@
 extern crate rand;
+extern crate futures;
+extern crate multiqueue;
 
 mod tree;
 mod buffer;
 mod editor;
+mod stream;
 
 pub use buffer::{Buffer, ReplicaId};
 pub use editor::Editor;

--- a/xray_core/src/stream.rs
+++ b/xray_core/src/stream.rs
@@ -1,0 +1,27 @@
+use futures::{Async, Poll, Stream};
+
+pub struct Last<T: Stream>(T);
+
+impl<T: Stream> Stream for Last<T> {
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let mut last_item;
+
+        match self.0.poll()? {
+            Async::NotReady => return Ok(Async::NotReady),
+            Async::Ready(None) => return Ok(Async::Ready(None)),
+            Async::Ready(i) => last_item = i,
+        }
+
+        loop {
+            match self.0.poll()? {
+                Async::NotReady => break,
+                Async::Ready(i) => last_item = i
+            }
+        }
+
+        Ok(Async::Ready(last_item))
+    }
+}


### PR DESCRIPTION
TODO:

* [x] Implement `Buffer.as_register_stream`
* [ ] Improve naming
* [ ] Extract `RegisterStream` into its own module
* [ ] Add tests for `Buffer.as_register_stream`
* [ ] Implement `Editor.as_register_stream`
* [ ] Add tests for `Editor.as_register_stream`