### PR TITLE
WIP: Compile on linux system

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -34,6 +34,7 @@ pub enum Status {
     Cancelled,
     EscapeCalledTwice,
     HandleScopeMismatch,
+    CallBackScopeMismatch,
     StringContainsNull
 }
 
@@ -236,7 +237,8 @@ impl From<sys::napi_status> for Status {
             napi_pending_exception => PendingException,
             napi_cancelled => Cancelled,
             napi_escape_called_twice => EscapeCalledTwice,
-            napi_handle_scope_mismatch => HandleScopeMismatch
+            napi_handle_scope_mismatch => HandleScopeMismatch,
+            napi_callback_scope_mismatch => CallBackScopeMismatch
         }
     }
 }

--- a/napi/src/sys/bindings.cc
+++ b/napi/src/sys/bindings.cc
@@ -3,6 +3,10 @@
 #include <node.h>
 #include <v8.h>
 
+#ifdef __unix__
+#include <string.h>
+#endif
+
 static
 v8::Local<v8::Value> V8LocalValueFromJsValue(napi_value v) {
   v8::Local<v8::Value> local;


### PR DESCRIPTION
added a preprocessor directive to add string.h to use memcpy on unix systems. 
There was also an unhandled match condition for napi_callback_scope_mismatch.

This is signaled as WIP since it does not actually generate a dylib in the target folder. I tried messing around in the build scripts but to no avail.