### PR TITLE
Linux Build Compatibility 

### DIFF
--- a/napi/scripts/napi.js
+++ b/napi/scripts/napi.js
@@ -3,7 +3,7 @@
 const parseArgs = require('minimist')
 const cp = require('child_process')
 const path = require('path')
-
+const os = require('os')
 const parsedNodeVersion = process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)$/)
 const nodeMajorVersion = parseInt(parsedNodeVersion[1])
 const nodeMinorVersion = parseInt(parsedNodeVersion[2])
@@ -24,12 +24,30 @@ const moduleName = path.basename(process.cwd());
 process.env.NODE_INCLUDE_PATH = nodeIncludePath
 process.env.NODE_MAJOR_VERSION = nodeMajorVersion
 
+const platform = os.platform()
+var libExt = ''
+
+switch(platform) {
+	case 'darwin':
+		libExt = '.dylib'
+		break;
+	case 'win32':
+		libExt = '.dll'
+		break;
+	case 'linux':
+		libExt = '.so'
+		break;
+	default:
+		console.error('Operating system not currently supported or recognized by the build script')
+		process.exit(1)
+}
+
 switch (subcommand) {
   case 'build':
     const releaseFlag = argv.release ? '--release' : ''
     const targetDir = argv.release ? 'release' : 'debug'
-    cp.execSync(`cargo rustc ${releaseFlag} -- -Clink-args=\"-undefined dynamic_lookup -export_dynamic\"`, {stdio: 'inherit'})
-    cp.execSync(`cp target/${targetDir}/{lib${moduleName}.dylib,${moduleName}.node}`, {stdio: 'inherit'})
+    cp.execSync(`cargo rustc ${releaseFlag} -- -Clink-args=\"-undefined,dynamic_lookup -export_dynamic\"`, {stdio: 'inherit'})
+    cp.execSync(`cp target/${targetDir}/lib${moduleName}${libExt} target/${targetDir}/${moduleName}.node`, {stdio: 'inherit'})
     break;
   case 'check':
     cp.execSync(`cargo check`, {stdio: 'inherit'})

--- a/napi/scripts/napi.js
+++ b/napi/scripts/napi.js
@@ -26,16 +26,21 @@ process.env.NODE_MAJOR_VERSION = nodeMajorVersion
 
 const platform = os.platform()
 var libExt = ''
+var platformArgs = ''
 
+// Platform based massaging for build commands
 switch(platform) {
 	case 'darwin':
 		libExt = '.dylib'
+		platformArgs = '-undefined dynamic_lookup -export_dynamic'
 		break;
 	case 'win32':
 		libExt = '.dll'
+		platformArgs = '-undefined dynamic_lookup -export_dynamic'
 		break;
 	case 'linux':
 		libExt = '.so'
+		platformArgs = '-undefined=dynamic_lookup -export_dynamic'
 		break;
 	default:
 		console.error('Operating system not currently supported or recognized by the build script')
@@ -46,7 +51,7 @@ switch (subcommand) {
   case 'build':
     const releaseFlag = argv.release ? '--release' : ''
     const targetDir = argv.release ? 'release' : 'debug'
-    cp.execSync(`cargo rustc ${releaseFlag} -- -Clink-args=\"-undefined,dynamic_lookup -export_dynamic\"`, {stdio: 'inherit'})
+    cp.execSync(`cargo rustc ${releaseFlag} -- -Clink-args=\"${platformArgs}\"`, {stdio: 'inherit'})
     cp.execSync(`cp target/${targetDir}/lib${moduleName}${libExt} target/${targetDir}/${moduleName}.node`, {stdio: 'inherit'})
     break;
   case 'check':

--- a/napi/src/sys/bindings.h
+++ b/napi/src/sys/bindings.h
@@ -1,5 +1,6 @@
 #include <node_api.h>
 #include <uv.h>
+#include <string.h>
 
 typedef struct extras_callback_scope__ *extras_callback_scope;
 


### PR DESCRIPTION
I changed the `napi` build script to work on Linux platforms in addition to MacOS. I am using the built-in Node.js `os` module to detect the user's system type in order to copy the correct dynamic library file. I also included `<string.h>` as I was having issues with `memcpy` not working on Ubuntu 16.04 LTS.

This address comments in #15 