### PR TITLE
add relative prefix to build script command

### DIFF
--- a/napi/scripts/napi.js
+++ b/napi/scripts/napi.js
@@ -51,10 +51,12 @@ switch (subcommand) {
     const releaseFlag = argv.release ? '--release' : ''
     const targetDir = argv.release ? 'release' : 'debug'
     cp.execSync(`cargo rustc ${releaseFlag} -- -Clink-args=\"${platformArgs}\"`, {stdio: 'inherit'})
-    cp.execSync(`cp target/${targetDir}/lib${moduleName}${libExt} target/${targetDir}/${moduleName}.node`, {stdio: 'inherit'})
+    cp.execSync(`cp ../target/${targetDir}/lib${moduleName}${libExt} ../target/${targetDir}/${moduleName}.node`, {stdio: 'inherit'})
     break
   case 'check':
     cp.execSync(`cargo check`, {stdio: 'inherit'})
+    break
   case 'doc':
     cp.execSync(`cargo doc`, {stdio: 'inherit'})
+    break
 }


### PR DESCRIPTION
Running Node 8.9.3 and Rust 1.24.1.

When running `npm install` from `xray_electron` as suggested in [contributing.md](https://github.com/atom/xray/blob/master/CONTRIBUTING.md), the napi.js script triggered during the Cargo compilation of `xray_node` didn't look for `target` at the outside layer, where the code is built,  but for a `target` folder inside the `xray_node` folder. Printing `pwd` from the child process _cp_ confirms that it is executing inside the `xray_node` folder.

Adding this relative path fixed the issue for me. I'm not sure why `{ stdio: 'inherit' }` doesn't work in the same way between lines 53 and 54. (Am new to rust and Cargo, is it something there?)

I also added two `break` statements to the other cases for execution clarity in the switch statement.