### PR TITLE
move rand to dev-dependencies

### DIFF
--- a/xray_core/Cargo.toml
+++ b/xray_core/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Nathan Sobo <nathan@github.com>"]
 license = "MIT"
 
 [dependencies]
-rand = "0.3"
 futures = "0.1"
 
 [dev-dependencies]
+rand = "0.3"
 futures-cpupool = "0.1"
 tokio-core = "0.1"

--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -927,6 +927,8 @@ fn find_insertion_index<T: Ord>(v: &Vec<T>, x: &T) -> usize {
 
 #[cfg(test)]
 mod tests {
+    extern crate rand;
+
     use super::*;
     use std::cmp::Ordering;
 
@@ -955,7 +957,7 @@ mod tests {
 
     #[test]
     fn random_splice() {
-        use rand::{Rng, SeedableRng, StdRng};
+        use self::rand::{Rng, SeedableRng, StdRng};
 
         for seed in 0..100 {
             println!("{:?}", seed);
@@ -1079,7 +1081,7 @@ mod tests {
     #[test]
     fn fragment_ids() {
         for seed in 0..10 {
-            use rand::{Rng, SeedableRng, StdRng};
+            use self::rand::{Rng, SeedableRng, StdRng};
             let mut rng = StdRng::from_seed(&[seed]);
 
             let mut ids = vec![FragmentId(vec![0]), FragmentId(vec![4])];

--- a/xray_core/src/lib.rs
+++ b/xray_core/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate rand;
 extern crate futures;
 
 mod notify_cell;

--- a/xray_core/src/notify_cell.rs
+++ b/xray_core/src/notify_cell.rs
@@ -88,12 +88,13 @@ impl<T: Clone> Drop for NotifyCell<T> {
 
 #[cfg(test)]
 mod tests {
+    extern crate rand;
     extern crate futures_cpupool;
 
     use super::*;
     use std::collections::BTreeSet;
     use futures::Future;
-    use rand::{self, Rng};
+    use self::rand::Rng;
     use self::futures_cpupool::CpuPool;
 
     #[test]

--- a/xray_core/src/tree.rs
+++ b/xray_core/src/tree.rs
@@ -480,6 +480,8 @@ impl<'tree, T: 'tree + Item> Cursor<'tree, T> {
 
 #[cfg(test)]
 mod tests {
+    extern crate rand;
+
     use super::*;
 
     #[derive(Default, Eq, PartialEq, Clone, Debug)]
@@ -582,7 +584,7 @@ mod tests {
     #[test]
     fn random() {
         for seed in 0..100 {
-            use rand::{Rng, SeedableRng, StdRng};
+            use self::rand::{Rng, SeedableRng, StdRng};
             let mut rng = StdRng::from_seed(&[seed]);
 
             let mut tree = Tree::<u16>::new();


### PR DESCRIPTION
I'm not sure how useful this pull request actually is but it gets rid of `rand` as a run-time dependency for `xray_core` as `rand` is only used for tests.