### PR TITLE
Optimize cursor movement and selection manipulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/xray_core/Cargo.toml
+++ b/xray_core/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 futures = "0.1"
+lazy_static = "1.0"
 
 [dev-dependencies]
 rand = "0.3"

--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::iter;
@@ -25,6 +26,7 @@ pub struct Buffer {
     lamport_clock: LamportTimestamp,
     fragments: Tree<Fragment>,
     insertions: HashMap<ChangeId, Tree<FragmentMapping>>,
+    position_cache: RefCell<HashMap<Anchor, (usize, Point)>>,
     pub version: NotifyCell<Version>
 }
 
@@ -37,10 +39,10 @@ pub struct Point {
     pub column: u32
 }
 
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
 pub struct Anchor(AnchorInner);
 
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
 enum AnchorInner {
     Start,
     End,
@@ -51,7 +53,7 @@ enum AnchorInner {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
 enum AnchorBias {
     Left,
     Right
@@ -144,6 +146,7 @@ impl Buffer {
             lamport_clock: 0,
             fragments,
             insertions: HashMap::new(),
+            position_cache: RefCell::new(HashMap::new()),
             version: NotifyCell::new(Version(0))
         }
     }
@@ -192,6 +195,7 @@ impl Buffer {
                 local_timestamp: self.local_clock
             };
             self.splice_fragments(change_id, old_range, new_text);
+            self.position_cache.borrow_mut().clear();
             self.version.set(Version(self.local_clock));
         }
     }
@@ -388,11 +392,18 @@ impl Buffer {
         let fragment = cursor.item().unwrap();
         let offset_in_fragment = offset - cursor.start::<CharacterCount>().0;
         let offset_in_insertion = fragment.start_offset + offset_in_fragment;
-        Ok(Anchor(AnchorInner::Middle {
+        let anchor = Anchor(AnchorInner::Middle {
             insertion_id: fragment.insertion.id,
             offset: offset_in_insertion,
             bias
-        }))
+        });
+
+        if let Ok(mut position_cache) = self.position_cache.try_borrow_mut() {
+            let point = cursor.start::<Point>() + &fragment.point_for_offset(offset_in_fragment)?;
+            position_cache.insert(anchor.clone(), (offset, point.clone()));
+        }
+
+        Ok(anchor)
     }
 
     pub fn anchor_before_point(&self, point: Point) -> Result<Anchor> {
@@ -432,70 +443,69 @@ impl Buffer {
         let fragment = cursor.item().unwrap();
         let offset_in_fragment = fragment.offset_for_point(point - &cursor.start::<Point>())?;
         let offset_in_insertion = fragment.start_offset + offset_in_fragment;
-        Ok(Anchor(AnchorInner::Middle {
+        let anchor = Anchor(AnchorInner::Middle {
             insertion_id: fragment.insertion.id,
             offset: offset_in_insertion,
             bias
-        }))
+        });
+
+        if let Ok(mut position_cache) = self.position_cache.try_borrow_mut() {
+            let offset = cursor.start::<CharacterCount>().0 + offset_in_fragment;
+            position_cache.insert(anchor.clone(), (offset, point.clone()));
+        }
+
+        Ok(anchor)
     }
 
     pub fn offset_for_anchor(&self, anchor: &Anchor) -> Result<usize> {
-        match &anchor.0 {
-            &AnchorInner::Start => Ok(0),
-            &AnchorInner::End => Ok(self.len()),
-            &AnchorInner::Middle { ref insertion_id, offset, ref bias } => {
-                let seek_bias = match bias {
-                    &AnchorBias::Left => SeekBias::Left,
-                    &AnchorBias::Right => SeekBias::Right,
-                };
-
-                let splits = self.insertions.get(&insertion_id).ok_or(Error::InvalidAnchor)?;
-                let mut splits_cursor = splits.cursor();
-                splits_cursor.seek(&InsertionOffset(offset), seek_bias);
-
-                splits_cursor.item().and_then(|split| {
-                    let mut fragments_cursor = self.fragments.cursor();
-                    fragments_cursor.seek(&split.fragment_id, SeekBias::Left);
-
-                    fragments_cursor.item().map(|fragment| {
-                        let overshoot = if fragment.is_visible() {
-                            offset - fragment.start_offset
-                        } else {
-                            0
-                        };
-                        fragments_cursor.start::<CharacterCount>().0 + overshoot
-                    })
-                }).ok_or(Error::InvalidAnchor)
-            }
-        }
+        Ok(self.position_for_anchor(anchor)?.0)
     }
 
     pub fn point_for_anchor(&self, anchor: &Anchor) -> Result<Point> {
+        Ok(self.position_for_anchor(anchor)?.1)
+    }
+
+    fn position_for_anchor(&self, anchor: &Anchor) -> Result<(usize, Point)> {
         match &anchor.0 {
-            &AnchorInner::Start => Ok(Point {row: 0, column: 0}),
-            &AnchorInner::End => Ok(self.fragments.len::<Point>()),
+            &AnchorInner::Start => Ok((0, Point {row: 0, column: 0})),
+            &AnchorInner::End => Ok((self.len(), self.fragments.len::<Point>())),
             &AnchorInner::Middle { ref insertion_id, offset, ref bias } => {
-                let seek_bias = match bias {
-                    &AnchorBias::Left => SeekBias::Left,
-                    &AnchorBias::Right => SeekBias::Right,
+                let position = {
+                    let position_cache = self.position_cache.try_borrow();
+                    position_cache.ok().and_then(|position_cache| position_cache.get(&anchor).cloned())
                 };
 
-                let splits = self.insertions.get(&insertion_id).ok_or(Error::InvalidAnchor)?;
-                let mut splits_cursor = splits.cursor();
-                splits_cursor.seek(&InsertionOffset(offset), seek_bias);
-                splits_cursor.item().ok_or(Error::InvalidAnchor).and_then(|split| {
-                    let mut fragments_cursor = self.fragments.cursor();
-                    fragments_cursor.seek(&split.fragment_id, SeekBias::Left);
-                    fragments_cursor.item().ok_or(Error::InvalidAnchor).and_then(|fragment| {
-                        let overshoot = if fragment.is_visible() {
-                            offset - fragment.start_offset
-                        } else {
-                            0
-                        };
+                if position.is_some() {
+                    Ok(position.unwrap())
+                } else {
+                    let seek_bias = match bias {
+                        &AnchorBias::Left => SeekBias::Left,
+                        &AnchorBias::Right => SeekBias::Right,
+                    };
 
-                        Ok(fragments_cursor.start::<Point>() + &fragment.point_for_offset(overshoot)?)
+                    let splits = self.insertions.get(&insertion_id).ok_or(Error::InvalidAnchor)?;
+                    let mut splits_cursor = splits.cursor();
+                    splits_cursor.seek(&InsertionOffset(offset), seek_bias);
+                    splits_cursor.item().ok_or(Error::InvalidAnchor).and_then(|split| {
+                        let mut fragments_cursor = self.fragments.cursor();
+                        fragments_cursor.seek(&split.fragment_id, SeekBias::Left);
+                        fragments_cursor.item().ok_or(Error::InvalidAnchor).and_then(|fragment| {
+                            let overshoot = if fragment.is_visible() {
+                                offset - fragment.start_offset
+                            } else {
+                                0
+                            };
+                            let offset = fragments_cursor.start::<CharacterCount>().0 + overshoot;
+                            let point = fragments_cursor.start::<Point>() + &fragment.point_for_offset(overshoot)?;
+
+                            if let Ok(mut position_cache) = self.position_cache.try_borrow_mut() {
+                                position_cache.insert(anchor.clone(), (offset, point));
+                            }
+
+                            Ok((offset, point))
+                        })
                     })
-                })
+                }
             }
         }
     }

--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -3,7 +3,6 @@ use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::ops::{Add, AddAssign, Sub, Range};
-use std::rc::Rc;
 use std::result;
 use std::sync::Arc;
 use super::tree::{self, Tree, SeekBias};
@@ -88,7 +87,7 @@ struct ChangeId {
 }
 
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Debug)]
-struct FragmentId(Rc<Vec<u16>>);
+struct FragmentId(Arc<Vec<u16>>);
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 struct Fragment {
@@ -721,13 +720,18 @@ impl<'a> From<Vec<u16>> for Text {
     }
 }
 
+lazy_static! {
+    static ref FRAGMENT_ID_MIN_VALUE: FragmentId = FragmentId(Arc::new(vec![0 as u16]));
+    static ref FRAGMENT_ID_MAX_VALUE: FragmentId = FragmentId(Arc::new(vec![u16::max_value()]));
+}
+
 impl FragmentId {
     fn min_value() -> Self {
-        FragmentId(Rc::new(vec![0 as u16]))
+        FRAGMENT_ID_MIN_VALUE.clone()
     }
 
     fn max_value() -> Self {
-        FragmentId(Rc::new(vec![u16::max_value()]))
+        FRAGMENT_ID_MAX_VALUE.clone()
     }
 
     fn between(left: &Self, right: &Self) -> Self {
@@ -749,7 +753,7 @@ impl FragmentId {
             }
         }
 
-        FragmentId(Rc::new(new_entries))
+        FragmentId(Arc::new(new_entries))
     }
 }
 
@@ -1098,7 +1102,7 @@ mod tests {
             use self::rand::{Rng, SeedableRng, StdRng};
             let mut rng = StdRng::from_seed(&[seed]);
 
-            let mut ids = vec![FragmentId(vec![0]), FragmentId(vec![4])];
+            let mut ids = vec![FragmentId(Arc::new(vec![0])), FragmentId(Arc::new(vec![4]))];
             for _i in 0..100 {
                 let index = rng.gen_range::<usize>(1, ids.len());
 

--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -3,6 +3,7 @@ use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::ops::{Add, AddAssign, Sub, Range};
+use std::rc::Rc;
 use std::result;
 use std::sync::Arc;
 use super::tree::{self, Tree, SeekBias};
@@ -87,7 +88,7 @@ struct ChangeId {
 }
 
 #[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Debug)]
-struct FragmentId(Vec<u16>);
+struct FragmentId(Rc<Vec<u16>>);
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 struct Fragment {
@@ -722,11 +723,11 @@ impl<'a> From<Vec<u16>> for Text {
 
 impl FragmentId {
     fn min_value() -> Self {
-        FragmentId(vec![0 as u16])
+        FragmentId(Rc::new(vec![0 as u16]))
     }
 
     fn max_value() -> Self {
-        FragmentId(vec![u16::max_value()])
+        FragmentId(Rc::new(vec![u16::max_value()]))
     }
 
     fn between(left: &Self, right: &Self) -> Self {
@@ -748,7 +749,7 @@ impl FragmentId {
             }
         }
 
-        FragmentId(new_entries)
+        FragmentId(Rc::new(new_entries))
     }
 }
 

--- a/xray_core/src/lib.rs
+++ b/xray_core/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate lazy_static;
 extern crate futures;
 
 mod notify_cell;


### PR DESCRIPTION
This pull request contains a few changes that will optimize selection manipulation and cursor movement. I'd recommend reviewing it on a per-commit basis:

* f1361e8 fixes a logic error that was using `Anchor::offset` as an offset into the fragment
* cc7ce29 caches anchor positions until the buffer is edited
* a829f24 wraps `FragmentId`'s vector of identifiers into an `Rc`
* 29b886e uses statically-allocated values for `FragmentId::{min, max}_value`
* 2d6c1b7 caches the mapping between offsets and points until the buffer is edited

I have tested the above optimizations following these steps:

* Edit the buffer 10000 times
* Add 1000 selections
* Start profiling
* Move right
* Stop profiling

| Before                                                                                                        | After                                                                                                        |
|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
| ![before](https://user-images.githubusercontent.com/482957/37458510-84e775e4-2845-11e8-9aff-29724c0a8323.png) | ![after](https://user-images.githubusercontent.com/482957/37458513-8633c790-2845-11e8-9c26-11196abac426.png) |

Note how the time spent in `TextEditor` (i.e., the call to `Editor::move_right`) has been reduced by a 35x factor. Performance is similar when moving cursors left, up or down.

### Next Steps

We think this is a good first improvement that will allow xray to stay well under the frame budget, even when the user is manipulating thousands of selections at the same time. We are currently focusing on other areas of the system and, therefore, we are thinking to put further improvements to this on hold until more architectural concerns have been sorted out. 

In the future we may revisit some areas of this code to optimize it even further, for example:

* Accesses to the B+ tree can have more cache-locality. Right now, accessing nodes and fragment ids always requires to follow a pointer wrapped by an `Arc`. This reduces the chances of having the data we need ready to consume in the cache during a tree traversal. As such, it might be interesting to explore using different representations for `Node` and `FragmentId` so that they are more cache-friendly.
* Reuse the same cursor across different tree traversals. Cursors use a `Vec` to represent a stack of  seen nodes during a traversal. While a single vector allocation is innocuous, doing one of them for each selection means we will repeatedly allocate a value on the heap and free it shortly afterward. By using the same (pool of) cursor(s) over and over again, we will minimize memory allocations, which we've learned to be very expensive on hot code paths like this. One implementation thought for this could be to instantiate a cursor during the initialization of a buffer, wrapping it in a `Arc`. Then, we could hand out clones of that `Arc` and, in order to use the cursor, callers will have to invoke `make_mut` on it. If the cursor is used by someone else, it will just be copied and only then we will pay for a heap allocation.
* Speed up `FragmentId` comparisons. When resolving the position of an anchor we may end up comparing many fragment identifiers. Right now the size of a fragment id isn't known at compile time, so the number of comparison operations is not constant. We can partially solve this by using a more cache-friendly representation like suggested above, but constant factors may still be relatively high. As such, another idea would be to explore using SIMD instructions to compare two arbitrary fragment ids. [This StackOverflow](https://stackoverflow.com/questions/6875128/how-to-compare-two-vectors-using-simd-and-get-a-single-boolean-result) thread gives some insights on how we could do that.
* Overall, minimize heap accesses and use the stack as much as possible.

/cc: @nathansobo 