### PR TITLE
Add keybindings for selecting ⬆️⬇️⬅️➡️ & adding selection above/below

### DIFF
--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -50,6 +50,8 @@ enum BufferViewAction {
     SelectDown,
     SelectLeft,
     SelectRight,
+    AddSelectionAbove,
+    AddSelectionBelow,
 }
 
 impl BufferView {
@@ -586,6 +588,8 @@ impl View for BufferView {
             Ok(BufferViewAction::SelectDown) => self.select_down(),
             Ok(BufferViewAction::SelectLeft) => self.select_left(),
             Ok(BufferViewAction::SelectRight) => self.select_right(),
+            Ok(BufferViewAction::AddSelectionAbove) => self.add_selection_above(),
+            Ok(BufferViewAction::AddSelectionBelow) => self.add_selection_below(),
             action @ _ => eprintln!("Unrecognized action {:?}", action),
         }
     }

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -46,6 +46,10 @@ enum BufferViewAction {
     MoveDown,
     MoveLeft,
     MoveRight,
+    SelectUp,
+    SelectDown,
+    SelectLeft,
+    SelectRight,
 }
 
 impl BufferView {
@@ -578,6 +582,10 @@ impl View for BufferView {
             Ok(BufferViewAction::MoveDown) => self.move_down(),
             Ok(BufferViewAction::MoveLeft) => self.move_left(),
             Ok(BufferViewAction::MoveRight) => self.move_right(),
+            Ok(BufferViewAction::SelectUp) => self.select_up(),
+            Ok(BufferViewAction::SelectDown) => self.select_down(),
+            Ok(BufferViewAction::SelectLeft) => self.select_left(),
+            Ok(BufferViewAction::SelectRight) => self.select_right(),
             action @ _ => eprintln!("Unrecognized action {:?}", action),
         }
     }

--- a/xray_electron/lib/render_process/text_editor/text_editor.js
+++ b/xray_electron/lib/render_process/text_editor/text_editor.js
@@ -115,31 +115,25 @@ class TextEditor extends React.Component {
       return;
     }
 
+    let action
     switch (event.key) {
-      case 'ArrowUp':
-        this.pauseCursorBlinking();
-        this.props.dispatch({
-          type: event.shiftKey ? 'SelectUp' : 'MoveUp'
-        });
+      case "ArrowUp":
+        action = event.shiftKey ? "SelectUp" : "MoveUp";
         break;
-      case 'ArrowDown':
-        this.pauseCursorBlinking();
-        this.props.dispatch({
-          type: event.shiftKey ? 'SelectDown' : 'MoveDown'
-        });
+      case "ArrowDown":
+        action = event.shiftKey ? "SelectDown" : "MoveDown";
         break;
-      case 'ArrowLeft':
-        this.pauseCursorBlinking();
-        this.props.dispatch({
-          type: event.shiftKey ? 'SelectLeft' : 'MoveLeft'
-        });
+      case "ArrowLeft":
+        action = event.shiftKey ? "SelectLeft" : "MoveLeft";
         break;
-      case 'ArrowRight':
-        this.pauseCursorBlinking();
-        this.props.dispatch({
-          type: event.shiftKey ? 'SelectRight' : 'MoveRight'
-        });
+      case "ArrowRight":
+        action = event.shiftKey ? "SelectRight" : "MoveRight";
         break;
+    }
+
+    if (action) {
+      this.pauseCursorBlinking();
+      this.props.dispatch({type: action});
     }
   }
 

--- a/xray_electron/lib/render_process/text_editor/text_editor.js
+++ b/xray_electron/lib/render_process/text_editor/text_editor.js
@@ -118,19 +118,27 @@ class TextEditor extends React.Component {
     switch (event.key) {
       case 'ArrowUp':
         this.pauseCursorBlinking();
-        this.props.dispatch({type: 'MoveUp'});
+        this.props.dispatch({
+          type: event.shiftKey ? 'SelectUp' : 'MoveUp'
+        });
         break;
       case 'ArrowDown':
         this.pauseCursorBlinking();
-        this.props.dispatch({type: 'MoveDown'});
+        this.props.dispatch({
+          type: event.shiftKey ? 'SelectDown' : 'MoveDown'
+        });
         break;
       case 'ArrowLeft':
         this.pauseCursorBlinking();
-        this.props.dispatch({type: 'MoveLeft'});
+        this.props.dispatch({
+          type: event.shiftKey ? 'SelectLeft' : 'MoveLeft'
+        });
         break;
       case 'ArrowRight':
         this.pauseCursorBlinking();
-        this.props.dispatch({type: 'MoveRight'});
+        this.props.dispatch({
+          type: event.shiftKey ? 'SelectRight' : 'MoveRight'
+        });
         break;
     }
   }

--- a/xray_electron/lib/render_process/text_editor/text_editor.js
+++ b/xray_electron/lib/render_process/text_editor/text_editor.js
@@ -115,22 +115,7 @@ class TextEditor extends React.Component {
       return;
     }
 
-    let action
-    switch (event.key) {
-      case "ArrowUp":
-        action = event.shiftKey ? "SelectUp" : "MoveUp";
-        break;
-      case "ArrowDown":
-        action = event.shiftKey ? "SelectDown" : "MoveDown";
-        break;
-      case "ArrowLeft":
-        action = event.shiftKey ? "SelectLeft" : "MoveLeft";
-        break;
-      case "ArrowRight":
-        action = event.shiftKey ? "SelectRight" : "MoveRight";
-        break;
-    }
-
+    const action = actionForKeyDownEvent(event);
     if (action) {
       this.pauseCursorBlinking();
       this.props.dispatch({type: action});
@@ -168,6 +153,31 @@ class TextEditor extends React.Component {
 
   focus() {
     this.element.focus();
+  }
+}
+
+function actionForKeyDownEvent (event) {
+  switch (event.key) {
+    case "ArrowUp":
+      if (event.ctrlKey && event.shiftKey) {
+        return "AddSelectionAbove"
+      } else if (event.shiftKey) {
+        return "SelectUp"
+      } else {
+        return "MoveUp"
+      }
+    case "ArrowDown":
+      if (event.ctrlKey && event.shiftKey) {
+        return "AddSelectionBelow"
+      } else if (event.shiftKey) {
+        return "SelectDown"
+      } else {
+        return "MoveDown"
+      }
+    case "ArrowLeft":
+      return event.shiftKey ? "SelectLeft" : "MoveLeft";
+    case "ArrowRight":
+      return event.shiftKey ? "SelectRight" : "MoveRight";
   }
 }
 


### PR DESCRIPTION
This pull request adds the following bindings:

- <kbd>shift</kbd> + <kbd>↑</kbd> = Select up
- <kbd>shift</kbd> + <kbd>↓</kbd> = Select down
- <kbd>shift</kbd> + <kbd>←</kbd> = Select left
- <kbd>shift</kbd> + <kbd>→</kbd> = Select right
- <kbd>control</kbd> + <kbd>shift</kbd> + <kbd>↑</kbd> = Add selection above
- <kbd>control</kbd> + <kbd>shift</kbd> + <kbd>↓</kbd> = Add selection below

### Demo

![demo](https://user-images.githubusercontent.com/2988/39336612-6ad37218-4986-11e8-856f-640480d2c434.gif)

![demo](https://user-images.githubusercontent.com/2988/39336613-6ae79e0a-4986-11e8-94da-ffa573307b04.gif)
