### PR TITLE
Install wasm-bindgen only if it is outdated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
 - nvm install v8.9.3
 - rustup target add wasm32-unknown-unknown
-- cargo install --force wasm-bindgen-cli
+- wasm-bindgen --version | grep 0.2.6 > /dev/null || cargo install --force wasm-bindgen-cli --version 0.2.6
 
 # Create a virtual display for electron
 - export DISPLAY=':99.0'


### PR DESCRIPTION
This pull request slightly changes .travis.yml to prevent it from installing wasm-bindgen over and over again, even when it's already installed in the Travis container.