### PR TITLE
Show selections of all workspace participants

### DIFF
--- a/xray_browser/script/server
+++ b/xray_browser/script/server
@@ -88,7 +88,6 @@ websocketServer.on("connection", async ws => {
 
 app.use(webpackDev(compiler, { publicPath: "/" }));
 app.use("/", express.static(path.join(__dirname, "../static")));
-// app.use("/", express.static(path.join(__dirname, "../dist")));
 server.listen(webServerPort, () => {
   console.log(`Using xray server: ${xrayServerAddress}:${xrayServerPort}`);
   console.log("Listening for HTTP connections on port " + webServerPort);

--- a/xray_core/src/app.rs
+++ b/xray_core/src/app.rs
@@ -209,7 +209,7 @@ impl App {
         };
     }
     
-    pub fn remove_window(&mut self, window_id: WindowId) -> Result<(), ()> {
+    pub fn close_window(&mut self, window_id: WindowId) -> Result<(), ()> {
         self.windows.remove(&window_id).map(|_| ()).ok_or(())
     }
 

--- a/xray_core/src/app.rs
+++ b/xray_core/src/app.rs
@@ -208,6 +208,10 @@ impl App {
             None => unimplemented!(),
         };
     }
+    
+    pub fn remove_window(&mut self, window_id: WindowId) -> Result<(), ()> {
+        self.windows.remove(&window_id).map(|_| ()).ok_or(())
+    }
 
     pub fn connect_to_client<S>(app: Rc<RefCell<App>>, incoming: S) -> server::Connection
     where

--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -446,7 +446,9 @@ pub mod rpc {
 
     impl Drop for Service {
         fn drop(&mut self) {
-            self.buffer.borrow_mut().remove_remote_selection_sets(self.replica_id);
+            self.buffer
+                .borrow_mut()
+                .remove_remote_selection_sets(self.replica_id);
         }
     }
 
@@ -930,7 +932,8 @@ impl Buffer {
     }
 
     fn remove_remote_selection_sets(&mut self, id: ReplicaId) {
-        self.selections.retain(|(replica_id, _), _| *replica_id != id);
+        self.selections
+            .retain(|(replica_id, _), _| *replica_id != id);
         self.updates.set(());
     }
 
@@ -2479,7 +2482,10 @@ mod tests {
         buffer_3_updates.wait_next(&mut reactor).unwrap();
         assert_eq!(selections(&buffer_1), selections(&buffer_3));
 
-        buffer_1.borrow_mut().remove_selection_set(buffer_1_set_id).unwrap();
+        buffer_1
+            .borrow_mut()
+            .remove_selection_set(buffer_1_set_id)
+            .unwrap();
         buffer_1_updates.wait_next(&mut reactor).unwrap();
 
         buffer_2_updates.wait_next(&mut reactor).unwrap();
@@ -2496,15 +2502,18 @@ mod tests {
         buffer_3_updates.wait_next(&mut reactor).unwrap();
         assert_eq!(selections(&buffer_1), selections(&buffer_3));
 
-        buffer_2.borrow_mut().mutate_selections(buffer_2_set_id, |buffer, selections| {
-            for selection in selections {
-                selection.start = buffer
-                    .anchor_before_offset(
-                        buffer.offset_for_anchor(&selection.start).unwrap() + 1,
-                    )
-                    .unwrap();
-            }
-        }).unwrap();
+        buffer_2
+            .borrow_mut()
+            .mutate_selections(buffer_2_set_id, |buffer, selections| {
+                for selection in selections {
+                    selection.start = buffer
+                        .anchor_before_offset(
+                            buffer.offset_for_anchor(&selection.start).unwrap() + 1,
+                        )
+                        .unwrap();
+                }
+            })
+            .unwrap();
 
         buffer_1_updates.wait_next(&mut reactor).unwrap();
         assert_eq!(selections(&buffer_2), selections(&buffer_1));

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -476,17 +476,6 @@ impl BufferView {
         let buffer = self.buffer.borrow();
         let mut rendered_selections = Vec::new();
 
-        for selection in
-            self.query_selections(&buffer.selections(self.selection_set_id).unwrap(), &range)
-        {
-            rendered_selections.push(SelectionProps {
-                replica_id: buffer.replica_id,
-                start: buffer.point_for_anchor(&selection.start).unwrap(),
-                end: buffer.point_for_anchor(&selection.end).unwrap(),
-                reversed: selection.reversed,
-            });
-        }
-
         for (replica_id, selections) in buffer.remote_selections() {
             for selection in self.query_selections(selections, &range) {
                 rendered_selections.push(SelectionProps {
@@ -496,6 +485,17 @@ impl BufferView {
                     reversed: selection.reversed,
                 });
             }
+        }
+
+        for selection in
+            self.query_selections(&buffer.selections(self.selection_set_id).unwrap(), &range)
+        {
+            rendered_selections.push(SelectionProps {
+                replica_id: buffer.replica_id,
+                start: buffer.point_for_anchor(&selection.start).unwrap(),
+                end: buffer.point_for_anchor(&selection.end).unwrap(),
+                reversed: selection.reversed,
+            });
         }
 
         rendered_selections

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -138,6 +138,7 @@ impl BufferView {
                 .collect();
         }
 
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -192,6 +193,7 @@ impl BufferView {
         }
 
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -255,6 +257,7 @@ impl BufferView {
         }
 
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -319,6 +322,7 @@ impl BufferView {
         }
 
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -344,6 +348,7 @@ impl BufferView {
             }
         }
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -361,6 +366,7 @@ impl BufferView {
             }
         }
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -386,6 +392,7 @@ impl BufferView {
             }
         }
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -403,6 +410,7 @@ impl BufferView {
             }
         }
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -426,6 +434,7 @@ impl BufferView {
             }
         }
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -441,6 +450,7 @@ impl BufferView {
             }
         }
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -464,6 +474,7 @@ impl BufferView {
             }
         }
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 
@@ -479,6 +490,7 @@ impl BufferView {
             }
         }
         self.merge_selections();
+        self.selections.borrow().updated();
         self.updated();
     }
 

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -593,7 +593,8 @@ impl View for BufferView {
             "height": self.height,
             "width": self.width,
             "line_height": self.line_height,
-            "selections": self.render_selections(start..end)
+            "selections": self.render_selections(start..end),
+            "local_replica_id": buffer.replica_id,
         })
     }
 

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -140,7 +140,7 @@ impl BufferView {
                         }
                     })
                     .collect();
-            });
+            }).unwrap();
         }
 
         self.updated();

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -121,26 +121,28 @@ impl BufferView {
             }
 
             let mut delta = 0_isize;
-            buffer.mutate_selections(self.selection_set_id, |buffer, selections| {
-                *selections = offset_ranges
-                    .into_iter()
-                    .map(|(start, end)| {
-                        let start = start as isize;
-                        let end = end as isize;
-                        let anchor = buffer
-                            .anchor_before_offset((start + delta) as usize + text.len())
-                            .unwrap();
-                        let deleted_count = end - start;
-                        delta += text.len() as isize - deleted_count;
-                        Selection {
-                            start: anchor.clone(),
-                            end: anchor,
-                            reversed: false,
-                            goal_column: None,
-                        }
-                    })
-                    .collect();
-            }).unwrap();
+            buffer
+                .mutate_selections(self.selection_set_id, |buffer, selections| {
+                    *selections = offset_ranges
+                        .into_iter()
+                        .map(|(start, end)| {
+                            let start = start as isize;
+                            let end = end as isize;
+                            let anchor = buffer
+                                .anchor_before_offset((start + delta) as usize + text.len())
+                                .unwrap();
+                            let deleted_count = end - start;
+                            delta += text.len() as isize - deleted_count;
+                            Selection {
+                                start: anchor.clone(),
+                                end: anchor,
+                                reversed: false,
+                                goal_column: None,
+                            }
+                        })
+                        .collect();
+                })
+                .unwrap();
         }
 
         self.updated();
@@ -640,7 +642,10 @@ impl Stream for BufferView {
 
 impl Drop for BufferView {
     fn drop(&mut self) {
-        self.buffer.borrow_mut().remove_selection_set(self.selection_set_id).unwrap();
+        self.buffer
+            .borrow_mut()
+            .remove_selection_set(self.selection_set_id)
+            .unwrap();
         self.dropped.set(true);
     }
 }

--- a/xray_core/src/fs.rs
+++ b/xray_core/src/fs.rs
@@ -75,7 +75,7 @@ pub struct RemoteTree(Rc<RefCell<RemoteTreeState>>);
 
 struct RemoteTreeState {
     root: Entry,
-    service: client::Service<TreeService>,
+    _service: client::Service<TreeService>,
     updates: NotifyCell<()>,
 }
 
@@ -259,7 +259,7 @@ impl RemoteTree {
         let updates = service.updates().unwrap();
         let state = Rc::new(RefCell::new(RemoteTreeState {
             root: service.state().unwrap(),
-            service,
+            _service: service,
             updates: NotifyCell::new(()),
         }));
 

--- a/xray_electron/lib/main_process/main.js
+++ b/xray_electron/lib/main_process/main.js
@@ -64,7 +64,10 @@ class XrayApplication {
       slashes: true
     }));
     this.windowsById.set(windowId, window);
-    window.on('closed', () => this.windowsById.delete(windowId));
+    window.on('closed', () => {
+      this.windowsById.delete(windowId);
+      this.xrayClient.sendMessage({type: 'CloseWindow', window_id: windowId});
+    });
   }
 }
 

--- a/xray_server/src/messages.rs
+++ b/xray_server/src/messages.rs
@@ -17,6 +17,9 @@ pub enum IncomingMessage {
         window_id: WindowId,
         height: f64,
     },
+    CloseWindow {
+        window_id: WindowId,
+    },
     OpenWorkspace {
         paths: Vec<PathBuf>,
     },

--- a/xray_ui/lib/app.js
+++ b/xray_ui/lib/app.js
@@ -14,7 +14,21 @@ const theme = {
     backgroundColor: "white",
     baseTextColor: "black",
     fontSize: 14,
-    lineHeight: 1.5
+    lineHeight: 1.5,
+    selectionColors: [
+      { r: 31, g: 150, b: 255, a: 125 },
+      { r: 64, g: 181, b: 87, a: 125 },
+      { r: 206, g: 157, b: 59, a: 125 },
+      { r: 216, g: 49, b: 176, a: 125 },
+      { r: 235, g: 221, b: 91, a: 125 },
+    ],
+    cursorColors: [
+      { r: 31, g: 150, b: 255, a: 255 },
+      { r: 64, g: 181, b: 87, a: 255 },
+      { r: 206, g: 157, b: 59, a: 255 },
+      { r: 216, g: 49, b: 176, a: 255 },
+      { r: 235, g: 221, b: 91, a: 255 },
+    ]
   }
 };
 

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -3,7 +3,7 @@ const ReactDOM = require("react-dom");
 const PropTypes = require("prop-types");
 const { styled } = require("styletron-react");
 const TextPlane = require("./text_plane");
-const debounce = require('../debounce');
+const debounce = require("../debounce");
 const $ = React.createElement;
 
 const CURSOR_BLINK_RESUME_DELAY = 300;
@@ -20,18 +20,18 @@ class TextEditor extends React.Component {
     let derivedState = null;
 
     if (nextProps.width != null && nextProps.width !== prevState.width) {
-      derivedState = {width: nextProps.width};
+      derivedState = { width: nextProps.width };
     }
 
     if (nextProps.height != null && nextProps.height !== prevState.height) {
       if (derivedState) {
         derivedState.height = nextProps.height;
       } else {
-        derivedState = {height: nextProps.height};
+        derivedState = { height: nextProps.height };
       }
     }
 
-    return derivedState
+    return derivedState;
   }
 
   constructor(props) {
@@ -43,13 +43,16 @@ class TextEditor extends React.Component {
       CURSOR_BLINK_RESUME_DELAY
     );
 
-    this.state = {showLocalCursors: true};
+    this.state = { showLocalCursors: true };
   }
 
   componentDidMount() {
     const element = ReactDOM.findDOMNode(this);
-    this.resizeObserver = new ResizeObserver(([{contentRect}]) => {
-      this.componentDidResize({width: contentRect.width, height: contentRect.height})
+    this.resizeObserver = new ResizeObserver(([{ contentRect }]) => {
+      this.componentDidResize({
+        width: contentRect.width,
+        height: contentRect.height
+      });
     });
     this.resizeObserver.observe(element);
 
@@ -59,10 +62,10 @@ class TextEditor extends React.Component {
         height: element.offsetHeight
       };
       this.componentDidResize(dimensions);
-      this.setState(dimensions)
+      this.setState(dimensions);
     }
 
-    element.addEventListener('wheel', this.handleMouseWheel, {passive: true});
+    element.addEventListener("wheel", this.handleMouseWheel, { passive: true });
 
     this.startCursorBlinking();
   }
@@ -70,16 +73,18 @@ class TextEditor extends React.Component {
   componentWillUnmount() {
     this.stopCursorBlinking();
     const element = ReactDOM.findDOMNode(this);
-    element.removeEventListener('wheel', this.handleMouseWheel, {passive: true});
+    element.removeEventListener("wheel", this.handleMouseWheel, {
+      passive: true
+    });
     this.resizeObserver.disconnect();
   }
 
   componentDidResize(measurements) {
     this.props.dispatch({
-      type: 'SetDimensions',
+      type: "SetDimensions",
       width: measurements.width,
       height: measurements.height
-    })
+    });
   }
 
   render() {
@@ -88,8 +93,8 @@ class TextEditor extends React.Component {
       {
         tabIndex: -1,
         onKeyDown: this.handleKeyDown,
-        $ref: (element) => {
-          this.element = element
+        $ref: element => {
+          this.element = element;
         }
       },
       $(TextPlane, {
@@ -101,18 +106,18 @@ class TextEditor extends React.Component {
         width: this.props.width,
         selections: this.props.selections,
         firstVisibleRow: this.props.first_visible_row,
-        lines: this.props.lines
+        lines: this.props.lines,
       })
     );
   }
 
   handleMouseWheel(event) {
-    this.props.dispatch({type: 'UpdateScrollTop', delta: event.deltaY});
+    this.props.dispatch({ type: "UpdateScrollTop", delta: event.deltaY });
   }
 
   handleKeyDown(event) {
     if (event.key.length === 1 && !event.metaKey) {
-      this.props.dispatch({type: 'Edit', text: event.key});
+      this.props.dispatch({ type: "Edit", text: event.key });
       return;
     } else if (event.key === 'Enter') {
       this.props.dispatch({type: 'Edit', text: '\n'});
@@ -122,19 +127,19 @@ class TextEditor extends React.Component {
     const action = actionForKeyDownEvent(event);
     if (action) {
       this.pauseCursorBlinking();
-      this.props.dispatch({type: action});
+      this.props.dispatch({ type: action });
     }
   }
 
-  pauseCursorBlinking () {
-    this.stopCursorBlinking()
-    this.debouncedStartCursorBlinking()
+  pauseCursorBlinking() {
+    this.stopCursorBlinking();
+    this.debouncedStartCursorBlinking();
   }
 
-  stopCursorBlinking () {
+  stopCursorBlinking() {
     if (this.state.cursorsBlinking) {
-      window.clearInterval(this.cursorBlinkIntervalHandle)
-      this.cursorBlinkIntervalHandle = null
+      window.clearInterval(this.cursorBlinkIntervalHandle);
+      this.cursorBlinkIntervalHandle = null;
       this.setState({
         showLocalCursors: true,
         cursorsBlinking: false
@@ -142,7 +147,7 @@ class TextEditor extends React.Component {
     }
   }
 
-  startCursorBlinking () {
+  startCursorBlinking() {
     if (!this.state.cursorsBlinking) {
       this.cursorBlinkIntervalHandle = window.setInterval(() => {
         this.setState({ showLocalCursors: !this.state.showLocalCursors });
@@ -160,23 +165,23 @@ class TextEditor extends React.Component {
   }
 }
 
-function actionForKeyDownEvent (event) {
+function actionForKeyDownEvent(event) {
   switch (event.key) {
     case "ArrowUp":
       if (event.ctrlKey && event.shiftKey) {
-        return "AddSelectionAbove"
+        return "AddSelectionAbove";
       } else if (event.shiftKey) {
-        return "SelectUp"
+        return "SelectUp";
       } else {
-        return "MoveUp"
+        return "MoveUp";
       }
     case "ArrowDown":
       if (event.ctrlKey && event.shiftKey) {
-        return "AddSelectionBelow"
+        return "AddSelectionBelow";
       } else if (event.shiftKey) {
-        return "SelectDown"
+        return "SelectDown";
       } else {
-        return "MoveDown"
+        return "MoveDown";
       }
     case "ArrowLeft":
       return event.shiftKey ? "SelectLeft" : "MoveLeft";

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -43,7 +43,7 @@ class TextEditor extends React.Component {
       CURSOR_BLINK_RESUME_DELAY
     );
 
-    this.state = {showCursors: true};
+    this.state = {showLocalCursors: true};
   }
 
   componentDidMount() {
@@ -93,7 +93,8 @@ class TextEditor extends React.Component {
         }
       },
       $(TextPlane, {
-        showCursors: this.state.showCursors,
+        showLocalCursors: this.state.showLocalCursors,
+        localReplicaId: this.props.local_replica_id,
         lineHeight: this.props.line_height,
         scrollTop: this.props.scroll_top,
         height: this.props.height,
@@ -135,7 +136,7 @@ class TextEditor extends React.Component {
       window.clearInterval(this.cursorBlinkIntervalHandle)
       this.cursorBlinkIntervalHandle = null
       this.setState({
-        showCursors: true,
+        showLocalCursors: true,
         cursorsBlinking: false
       });
     }
@@ -144,12 +145,12 @@ class TextEditor extends React.Component {
   startCursorBlinking () {
     if (!this.state.cursorsBlinking) {
       this.cursorBlinkIntervalHandle = window.setInterval(() => {
-        this.setState({ showCursors: !this.state.showCursors });
+        this.setState({ showLocalCursors: !this.state.showLocalCursors });
       }, CURSOR_BLINK_PERIOD / 2);
 
       this.setState({
         cursorsBlinking: true,
-        showCursors: false
+        showLocalCursors: false
       });
     }
   }


### PR DESCRIPTION
This pull request moves selection ownership down into the buffer so that it can replicated to all workspace participants. We then tweaked the WebGL rendering to assign one of five different colors to selections based on the id of the replica that owns the selection and limit blinking to local cursors only.

<img width="829" alt="screen shot 2018-05-02 at 17 16 24" src="https://user-images.githubusercontent.com/482957/39531945-9b1c6f24-4e2c-11e8-9964-547d7c3c2065.png">
