### PR TITLE
Remove '+nightly' option from xray_wasm/scripts/build

### DIFF
--- a/xray_wasm/script/build
+++ b/xray_wasm/script/build
@@ -15,5 +15,5 @@ setup_wasm_bindgen() {
 rustup target add wasm32-unknown-unknown
 setup_wasm_bindgen
 mkdir -p dist
-CARGO_INCREMENTAL=0 RUSTFLAGS="-C debuginfo=0 -C opt-level=s -C lto -C panic=abort" cargo +nightly build --release --target wasm32-unknown-unknown
+CARGO_INCREMENTAL=0 RUSTFLAGS="-C debuginfo=0 -C opt-level=s -C lto -C panic=abort" cargo build --release --target wasm32-unknown-unknown
 wasm-bindgen ../target/wasm32-unknown-unknown/release/xray_wasm.wasm --out-dir dist


### PR DESCRIPTION
Already 'rust-toolchain' exists, but '+nightly' override toolchain.
We expect nightly-2018-04-27 (from 'rust-toolchain'), but use latest nightly-toolchain.

In my environment(latest nightly installed), problems similar to issue # 72 were occurring.