### PR TITLE
Optimize `add_selection_above` and `add_selection_below`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,11 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "seahash"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1141,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1257,6 +1263,7 @@ dependencies = [
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8674d439c964889e2476f474a3bf198cc9e199e77499960893bac5de7e9218a4"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum seahash 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e048636bed25842fcdc36e5ad1ec6295b72d4b5b8a4b759b64915a4ce2b9d09d"
 "checksum serde 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "53e6b6859395f46cf528414659ce43e70902b2277519707c3bd91797b3320330"
 "checksum serde_derive 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "16e97f8dc5b2dabc0183e0cde24b1a53835e5bb3d2c9e0fdb077f895bba7f2a9"
 "checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"

--- a/xray_core/Cargo.toml
+++ b/xray_core/Cargo.toml
@@ -10,6 +10,7 @@ bytes = { version ="0.4", features = ["serde"] }
 futures = "0.1"
 lazy_static = "1.0"
 parking_lot = "0.5"
+seahash = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/xray_core/benches/bench.rs
+++ b/xray_core/benches/bench.rs
@@ -5,23 +5,61 @@ extern crate criterion;
 use criterion::Criterion;
 use std::cell::RefCell;
 use std::rc::Rc;
-use xray_core::buffer::Buffer;
+use xray_core::buffer::{Buffer, Point};
 use xray_core::buffer_view::BufferView;
 
-fn bench_edit() {
-    let content = String::from("abcdefghijklmnopqrstuvwxyz");
-    let mut buffer = Buffer::new(0);
-    buffer.edit(0..0, content.as_str());
-    let mut editor = BufferView::new(Rc::new(RefCell::new(buffer)), 0, None);
-    for _ in 0..content.len() {
-        editor.select_right();
-        editor.edit("-");
-    }
+fn add_selection(c: &mut Criterion) {
+    c.bench_function("add_selection_below", |b| {
+        b.iter_with_setup(
+            || {
+                let mut buffer_view = create_buffer_view(100);
+                for i in 0..100 {
+                    buffer_view.add_selection(Point::new(i, 0), Point::new(i, 0));
+                }
+                buffer_view
+            },
+            |mut buffer_view| buffer_view.add_selection_below(),
+        )
+    });
+    c.bench_function("add_selection_above", |b| {
+        b.iter_with_setup(
+            || {
+                let mut buffer_view = create_buffer_view(100);
+                for i in 0..100 {
+                    buffer_view.add_selection(Point::new(i, 0), Point::new(i, 0));
+                }
+                buffer_view
+            },
+            |mut buffer_view| buffer_view.add_selection_above(),
+        )
+    });
 }
 
 fn edit(c: &mut Criterion) {
-    c.bench_function("edit", |b| b.iter(|| bench_edit()));
+    c.bench_function("edit", |b| {
+        b.iter_with_setup(
+            || create_buffer_view(10),
+            |mut buffer_view| {
+                for _ in 0..25 {
+                    buffer_view.select_right();
+                    buffer_view.edit("-");
+                }
+            },
+        )
+    });
 }
 
-criterion_group!(benches, edit);
+fn create_buffer_view(lines: usize) -> BufferView {
+    let mut buffer = Buffer::new(0);
+    for i in 0..lines {
+        let len = buffer.len();
+        buffer.edit(
+            len..len,
+            format!("Lorem ipsum dolor sit amet {}\n", i).as_str(),
+        );
+    }
+    BufferView::new(Rc::new(RefCell::new(buffer)), 0, None)
+}
+
+criterion_group!(benches, edit, add_selection);
 criterion_main!(benches);

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -270,7 +270,7 @@ impl BufferView {
     pub fn add_selection_above(&mut self) {
         self.buffer
             .borrow_mut()
-            .mutate_selections(self.selection_set_id, |buffer, selections| {
+            .insert_selections(self.selection_set_id, |buffer, selections| {
                 let mut new_selections = Vec::new();
                 for selection in selections.iter() {
                     let selection_start = buffer.point_for_anchor(&selection.start).unwrap();
@@ -313,16 +313,7 @@ impl BufferView {
                         }
                     }
                 }
-
-                for selection in new_selections {
-                    let index = match selections.binary_search_by(|probe| {
-                        buffer.cmp_anchors(&probe.start, &selection.start).unwrap()
-                    }) {
-                        Ok(index) => index,
-                        Err(index) => index,
-                    };
-                    selections.insert(index, selection);
-                }
+                new_selections
             })
             .unwrap();
         self.autoscroll_to_cursor(false);
@@ -331,7 +322,7 @@ impl BufferView {
     pub fn add_selection_below(&mut self) {
         self.buffer
             .borrow_mut()
-            .mutate_selections(self.selection_set_id, |buffer, selections| {
+            .insert_selections(self.selection_set_id, |buffer, selections| {
                 let max_row = buffer.max_point().row;
 
                 let mut new_selections = Vec::new();
@@ -376,16 +367,7 @@ impl BufferView {
                         }
                     }
                 }
-
-                for selection in new_selections {
-                    let index = match selections.binary_search_by(|probe| {
-                        buffer.cmp_anchors(&probe.start, &selection.start).unwrap()
-                    }) {
-                        Ok(index) => index,
-                        Err(index) => index,
-                    };
-                    selections.insert(index, selection);
-                }
+                new_selections
             })
             .unwrap();
         self.autoscroll_to_cursor(false);

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -1210,9 +1210,13 @@ mod tests {
             .set_scroll_top(2.5 * line_height);
         assert_eq!(editor.scroll_top(), 2.5 * line_height);
 
-        editor.autoscroll_to_range(start.clone()..start.clone(), true).unwrap();
+        editor
+            .autoscroll_to_range(start.clone()..start.clone(), true)
+            .unwrap();
         assert_eq!(editor.scroll_top(), 0.0);
-        editor.autoscroll_to_range(end.clone()..end.clone(), true).unwrap();
+        editor
+            .autoscroll_to_range(end.clone()..end.clone(), true)
+            .unwrap();
         assert_eq!(
             editor.scroll_top(),
             (max_point.row as f64 * line_height) - (height / 2.0)

--- a/xray_core/src/lib.rs
+++ b/xray_core/src/lib.rs
@@ -7,6 +7,7 @@ extern crate bytes;
 extern crate lazy_static;
 extern crate futures;
 extern crate parking_lot;
+extern crate seahash;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Previously, dispatching the "Add Selection Above/Below" command was unusable even when the number of existing selections was relatively low (e.g. < 1000 selections). This pull request introduces a few commits that improve the situation and allow to use this command even with thousands of selections (in my tests, we don't drop any frame even with > 2000 selections):

* Use only one malloc and move selections only once when merging them (67b8821)
* Use SeaHash for position caches in Buffer (af545d2)
* Introduce `Buffer::insert_selections` to efficiently insert a (not necessarily sorted) list of selections (b75e52c)

Other than some local tests, I have also introduced a benchmark that proves the above changes have a positive effect on the `Buffer::add_selection_above` and `Buffer::add_selection_below` methods:

<img width="953" alt="benchmark" src="https://user-images.githubusercontent.com/482957/39696017-aff1653a-51ec-11e8-853c-aaaaaa07b090.png">

Note that, for speed purposes, I have kept the number of selections in the benchmark relatively low. Even in that scenario the proposed changes make a significant difference, but the improvements increase even more when the number of selections gets higher (i.e. thousands as opposed to hundreds of selections). This is largely due to `memmove` calls being still quite efficient when `Vec` is small.

/cc: @nathansobo 