### PR TITLE
Splice buffer fragments in batches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,3 @@ members = [
     "xray_cli",
     "xray_wasm",
 ]
-
-[profile.release]
-debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "xray_cli",
     "xray_wasm",
 ]
+
+[profile.release]
+debug = true

--- a/xray_core/benches/bench.rs
+++ b/xray_core/benches/bench.rs
@@ -38,12 +38,17 @@ fn add_selection(c: &mut Criterion) {
 fn edit(c: &mut Criterion) {
     c.bench_function("edit", |b| {
         b.iter_with_setup(
-            || create_buffer_view(10),
-            |mut buffer_view| {
-                for _ in 0..25 {
-                    buffer_view.select_right();
-                    buffer_view.edit("-");
+            || {
+                let mut buffer_view = create_buffer_view(50);
+                for i in 0..50 {
+                    buffer_view.add_selection(Point::new(i, 0), Point::new(i, 0));
                 }
+                buffer_view
+            },
+            |mut buffer_view| {
+                buffer_view.edit("a");
+                buffer_view.edit("b");
+                buffer_view.edit("c");
             },
         )
     });
@@ -54,7 +59,7 @@ fn create_buffer_view(lines: usize) -> BufferView {
     for i in 0..lines {
         let len = buffer.len();
         buffer.edit(
-            len..len,
+            &[len..len],
             format!("Lorem ipsum dolor sit amet {}\n", i).as_str(),
         );
     }

--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -682,14 +682,14 @@ impl Buffer {
             None
         };
 
-        // TODO: Go back to using an iterator and pass it to splice_fragments.
-        let old_ranges = old_ranges
-            .into_iter()
-            .filter(|old_range| new_text.is_some() || old_range.end > old_range.start);
-
-        let ops = self.splice_fragments(old_ranges, new_text.clone());
         self.anchor_cache.borrow_mut().clear();
         self.offset_cache.borrow_mut().clear();
+        let ops = self.splice_fragments(
+            old_ranges
+                .into_iter()
+                .filter(|old_range| new_text.is_some() || old_range.end > old_range.start),
+            new_text.clone(),
+        );
         for op in &ops {
             self.broadcast_op(op);
         }

--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -1046,19 +1046,19 @@ impl Buffer {
 
     fn splice_fragments<'a, I>(
         &mut self,
-        mut ranges: I,
+        mut old_ranges: I,
         new_text: Option<Arc<Text>>,
     ) -> Vec<Arc<Operation>>
     where
         I: Iterator<Item = &'a Range<usize>>,
     {
-        let mut cur_range = ranges.next();
+        let mut cur_range = old_ranges.next();
         if cur_range.is_none() {
             return Vec::new();
         }
 
         let replica_id = self.replica_id;
-        let mut ops = Vec::with_capacity(ranges.size_hint().0);
+        let mut ops = Vec::with_capacity(old_ranges.size_hint().0);
 
         let old_fragments = self.fragments.clone();
         let mut cursor = old_fragments.cursor();
@@ -1193,7 +1193,7 @@ impl Buffer {
                     end_id = None;
                     end_offset = None;
                     version_in_range = Version::new();
-                    cur_range = ranges.next();
+                    cur_range = old_ranges.next();
                     if cur_range.is_some() {
                         self.local_clock += 1;
                         self.lamport_clock += 1;
@@ -1254,7 +1254,7 @@ impl Buffer {
                             end_offset = None;
                             version_in_range = Version::new();
 
-                            cur_range = ranges.next();
+                            cur_range = old_ranges.next();
                             if cur_range.is_some() {
                                 self.local_clock += 1;
                                 self.lamport_clock += 1;
@@ -1281,7 +1281,7 @@ impl Buffer {
         // Handle range that is at the end of the buffer if it exists. There should never be
         // multiple because ranges must be disjoint.
         if cur_range.is_some() {
-            debug_assert_eq!(ranges.next(), None);
+            debug_assert_eq!(old_ranges.next(), None);
             let local_timestamp = self.local_clock;
             let lamport_timestamp = self.lamport_clock;
             let id = EditId {

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -159,7 +159,7 @@ impl BufferView {
             }
 
             let mut buffer = self.buffer.borrow_mut();
-            buffer.edit(offset_ranges.iter().rev(), text);
+            buffer.edit(&offset_ranges, text);
 
             let mut delta = 0_isize;
             buffer

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -154,23 +154,21 @@ impl BufferView {
                 for selection in self.selections().iter() {
                     let start = buffer.offset_for_anchor(&selection.start).unwrap();
                     let end = buffer.offset_for_anchor(&selection.end).unwrap();
-                    offset_ranges.push((start, end));
+                    offset_ranges.push(start..end);
                 }
             }
 
             let mut buffer = self.buffer.borrow_mut();
-            for &(start, end) in offset_ranges.iter().rev() {
-                buffer.edit(start..end, text);
-            }
+            buffer.edit(offset_ranges.iter().rev(), text);
 
             let mut delta = 0_isize;
             buffer
                 .mutate_selections(self.selection_set_id, |buffer, selections| {
                     *selections = offset_ranges
                         .into_iter()
-                        .map(|(start, end)| {
-                            let start = start as isize;
-                            let end = end as isize;
+                        .map(|range| {
+                            let start = range.start as isize;
+                            let end = range.end as isize;
                             let anchor = buffer
                                 .anchor_before_offset((start + delta) as usize + text.len())
                                 .unwrap();
@@ -795,9 +793,9 @@ mod tests {
     #[test]
     fn test_cursor_movement() {
         let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
-        editor.buffer.borrow_mut().edit(0..0, "abc");
-        editor.buffer.borrow_mut().edit(3..3, "\n");
-        editor.buffer.borrow_mut().edit(4..4, "\ndef");
+        editor.buffer.borrow_mut().edit(&[0..0], "abc");
+        editor.buffer.borrow_mut().edit(&[3..3], "\n");
+        editor.buffer.borrow_mut().edit(&[4..4], "\ndef");
         assert_eq!(render_selections(&editor), vec![empty_selection(0, 0)]);
 
         editor.move_right();
@@ -876,9 +874,9 @@ mod tests {
     #[test]
     fn test_selection_movement() {
         let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
-        editor.buffer.borrow_mut().edit(0..0, "abc");
-        editor.buffer.borrow_mut().edit(3..3, "\n");
-        editor.buffer.borrow_mut().edit(4..4, "\ndef");
+        editor.buffer.borrow_mut().edit(&[0..0], "abc");
+        editor.buffer.borrow_mut().edit(&[3..3], "\n");
+        editor.buffer.borrow_mut().edit(&[4..4], "\ndef");
 
         assert_eq!(render_selections(&editor), vec![empty_selection(0, 0)]);
 
@@ -967,7 +965,7 @@ mod tests {
     #[test]
     fn test_backspace() {
         let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
-        editor.buffer.borrow_mut().edit(0..0, "abcdefghi");
+        editor.buffer.borrow_mut().edit(&[0..0], "abcdefghi");
         editor.add_selection(Point::new(0, 3), Point::new(0, 4));
         editor.add_selection(Point::new(0, 9), Point::new(0, 9));
         editor.backspace();
@@ -979,7 +977,7 @@ mod tests {
     #[test]
     fn test_delete() {
         let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
-        editor.buffer.borrow_mut().edit(0..0, "abcdefghi");
+        editor.buffer.borrow_mut().edit(&[0..0], "abcdefghi");
         editor.add_selection(Point::new(0, 3), Point::new(0, 4));
         editor.add_selection(Point::new(0, 9), Point::new(0, 9));
         editor.delete();
@@ -994,7 +992,7 @@ mod tests {
         editor
             .buffer
             .borrow_mut()
-            .edit(0..0, "abcd\nefgh\nijkl\nmnop");
+            .edit(&[0..0], "abcd\nefgh\nijkl\nmnop");
         assert_eq!(render_selections(&editor), vec![empty_selection(0, 0)]);
 
         // Adding non-overlapping selections
@@ -1046,7 +1044,7 @@ mod tests {
     fn test_add_selection_above() {
         let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
         editor.buffer.borrow_mut().edit(
-            0..0,
+            &[0..0],
             "\
              abcdefghijk\n\
              lmnop\n\
@@ -1115,7 +1113,7 @@ mod tests {
     fn test_add_selection_below() {
         let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
         editor.buffer.borrow_mut().edit(
-            0..0,
+            &[0..0],
             "\
              abcdefgh\n\
              ijklm\n\
@@ -1175,7 +1173,10 @@ mod tests {
     fn test_edit() {
         let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
 
-        editor.buffer.borrow_mut().edit(0..0, "abcdefgh\nhijklmno");
+        editor
+            .buffer
+            .borrow_mut()
+            .edit(&[0..0], "abcdefgh\nhijklmno");
 
         // Three selections on the same line
         editor.select_right();
@@ -1197,7 +1198,7 @@ mod tests {
     #[test]
     fn test_autoscroll() {
         let mut buffer = Buffer::new(0);
-        buffer.edit(0..0, "abc\ndef\nghi\njkl\nmno\npqr\nstu\nvwx\nyz");
+        buffer.edit(&[0..0], "abc\ndef\nghi\njkl\nmno\npqr\nstu\nvwx\nyz");
         let start = buffer.anchor_before_offset(0).unwrap();
         let end = buffer.anchor_before_offset(buffer.len()).unwrap();
         let max_point = buffer.max_point();
@@ -1228,7 +1229,7 @@ mod tests {
         let buffer = Rc::new(RefCell::new(Buffer::new(0)));
         buffer
             .borrow_mut()
-            .edit(0..0, "abc\ndef\nghi\njkl\nmno\npqr\nstu\nvwx\nyz");
+            .edit(&[0..0], "abc\ndef\nghi\njkl\nmno\npqr\nstu\nvwx\nyz");
         let line_height = 6.0;
 
         {
@@ -1299,7 +1300,7 @@ mod tests {
     fn test_render_past_last_line() {
         let line_height = 4.0;
         let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
-        editor.buffer.borrow_mut().edit(0..0, "abc\ndef\nghi");
+        editor.buffer.borrow_mut().edit(&[0..0], "abc\ndef\nghi");
         editor.add_selection(Point::new(2, 3), Point::new(2, 3));
         editor
             .set_height(3.0 * line_height)

--- a/xray_core/src/project.rs
+++ b/xray_core/src/project.rs
@@ -187,7 +187,7 @@ impl Project for LocalProject {
                                         let buffer_id = next_buffer_id_cell.get();
                                         next_buffer_id_cell.set(next_buffer_id_cell.get() + 1);
                                         let mut buffer = Buffer::new(buffer_id);
-                                        buffer.edit(0..0, content.as_str());
+                                        buffer.edit(&[0..0], content.as_str());
                                         let buffer = buffer.into_shared();
                                         buffers.borrow_mut().insert(buffer_id, buffer.clone());
                                         buffer

--- a/xray_core/src/tree.rs
+++ b/xray_core/src/tree.rs
@@ -114,6 +114,10 @@ impl<'a, T: Item> Tree<T> {
         D::from_summary(self.summary())
     }
 
+    pub fn last(&self) -> Option<&T> {
+        self.rightmost_leaf().map(|leaf| leaf.value())
+    }
+
     pub fn push(&mut self, item: T) {
         self.push_tree(Tree(Arc::new(Node::Leaf {
             summary: item.summarize(),


### PR DESCRIPTION
This pull request takes advantage of the batched nature of multi-cursor editing to improve performance when manipulating the buffer. The following chart shows that, after these changes, editing is ~66% faster on average:

<img width="952" alt="screen shot 2018-05-10 at 15 51 41" src="https://user-images.githubusercontent.com/482957/39873261-b5531c00-546a-11e8-8a50-6e8cb1baeffc.png">

`Buffer::splice_fragments` has now become a little more involved due to trying to reuse as much work as possible from previous edits. I think it's still pretty reasonable though and I have tried to document the various logical steps in the function's body.

Please note that we're still far from being optimal when modifying the buffer. Specifically, based on my measurements, `Cursor::seek_and_slice` becomes slower and slower as more fragments are added to the tree. This seems to be due to the cost of constructing the slices in between ranges but that code path has quite a lot of room for improvement still and we should get back to it at some point.

/cc: @nathansobo 