### PR TITLE
Implement saving feature for buffers

### DIFF
--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -1661,7 +1661,8 @@ impl BufferSnapshot {
     pub fn iter<'a>(&'a self) -> impl 'a + Iterator<Item = &'a [u16]> {
         self.fragments.iter().filter_map(|fragment| {
             if fragment.is_visible() {
-                Some(fragment.insertion.text.code_units.as_ref())
+                let range = fragment.start_offset..fragment.end_offset;
+                Some(&fragment.insertion.text.code_units[range])
             } else {
                 None
             }

--- a/xray_core/src/fs.rs
+++ b/xray_core/src/fs.rs
@@ -1,3 +1,4 @@
+use buffer::BufferSnapshot;
 use cross_platform;
 use futures::{Async, Future, Stream};
 use notify_cell::NotifyCell;
@@ -35,6 +36,10 @@ pub trait FileProvider {
 pub trait File {
     fn id(&self) -> FileId;
     fn read(&self) -> Box<Future<Item = String, Error = io::Error>>;
+    fn write_snapshot(
+        &self,
+        snapshot: BufferSnapshot,
+    ) -> Box<Future<Item = (), Error = io::Error>>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/xray_core/src/fs.rs
+++ b/xray_core/src/fs.rs
@@ -36,10 +36,8 @@ pub trait FileProvider {
 pub trait File {
     fn id(&self) -> FileId;
     fn read(&self) -> Box<Future<Item = String, Error = io::Error>>;
-    fn write_snapshot(
-        &self,
-        snapshot: BufferSnapshot,
-    ) -> Box<Future<Item = (), Error = io::Error>>;
+    fn write_snapshot(&self, snapshot: BufferSnapshot)
+        -> Box<Future<Item = (), Error = io::Error>>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -545,6 +543,18 @@ pub(crate) mod tests {
             Box::new(NextTick::new().then(move |_| {
                 let file = file.borrow();
                 future::ok(file.content.clone())
+            }))
+        }
+
+        fn write_snapshot(
+            &self,
+            snapshot: BufferSnapshot,
+        ) -> Box<Future<Item = (), Error = io::Error>> {
+            let file = self.0.clone();
+            Box::new(NextTick::new().then(move |_| {
+                let mut file = file.borrow_mut();
+                file.content = snapshot.to_string();
+                future::ok(())
             }))
         }
     }

--- a/xray_core/src/workspace.rs
+++ b/xray_core/src/workspace.rs
@@ -7,8 +7,10 @@ use futures::{Future, Poll, Stream};
 use never::Never;
 use notify_cell::NotifyCell;
 use notify_cell::NotifyCellObserver;
-use project::{self, LocalProject, PathSearch, PathSearchStatus, Project, ProjectService,
-              RemoteProject, TreeId};
+use project::{
+    self, LocalProject, PathSearch, PathSearchStatus, Project, ProjectService, RemoteProject,
+    TreeId,
+};
 use rpc::{self, client, server};
 use serde_json;
 use std::cell::{Ref, RefCell, RefMut};
@@ -216,7 +218,7 @@ impl WorkspaceView {
 
     fn open_buffer<T>(&self, buffer: T, selected_range: Option<Range<buffer::Anchor>>)
     where
-        T: 'static + Future<Item = Rc<RefCell<Buffer>>, Error = project::OpenError>,
+        T: 'static + Future<Item = Rc<RefCell<Buffer>>, Error = project::Error>,
     {
         if let Some(window_handle) = self.window_handle.clone() {
             let user_id = self.workspace.borrow().user_id();

--- a/xray_server/src/fs.rs
+++ b/xray_server/src/fs.rs
@@ -1,13 +1,15 @@
 use futures::{self, Future, Stream};
 use ignore::WalkBuilder;
 use parking_lot::Mutex;
+use std::char::decode_utf16;
 use std::ffi::OsString;
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
+use xray_core::buffer::BufferSnapshot;
 use xray_core::cross_platform;
 use xray_core::fs as xray_fs;
 use xray_core::notify_cell::NotifyCell;
@@ -139,7 +141,10 @@ impl xray_fs::FileProvider for FileProvider {
 
         thread::spawn(|| {
             fn open(path: PathBuf) -> Result<File, io::Error> {
-                Ok(File::new(fs::File::open(path)?)?)
+                Ok(File::new(fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(path)?)?)
             }
 
             let _ = tx.send(open(path));
@@ -180,6 +185,37 @@ impl xray_fs::File for File {
             let _ = tx.send(read(&file.lock()));
         });
 
+        Box::new(rx.then(|result| result.expect("Sender should not be dropped")))
+    }
+
+    fn write_snapshot(
+        &self,
+        snapshot: BufferSnapshot,
+    ) -> Box<Future<Item = (), Error = io::Error>> {
+        let (tx, rx) = futures::sync::oneshot::channel();
+        let file = self.file.clone();
+        thread::spawn(move || {
+            fn write(file: &mut fs::File, snapshot: BufferSnapshot) -> Result<(), io::Error> {
+                let mut buf_writer = io::BufWriter::new(file);
+                let mut encode_buf = [0_u8; 4];
+                for character in snapshot
+                    .iter()
+                    .flat_map(|c| decode_utf16(c.iter().cloned()))
+                {
+                    let character = character.map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "buffer did not contain valid UTF-8",
+                        )
+                    })?;
+                    let encoded_char = character.encode_utf8(&mut encode_buf);
+                    buf_writer.write(encoded_char.as_bytes())?;
+                }
+                Ok(())
+            }
+
+            let _ = tx.send(write(&mut file.lock(), snapshot));
+        });
         Box::new(rx.then(|result| result.expect("Sender should not be dropped")))
     }
 }

--- a/xray_ui/lib/workspace.js
+++ b/xray_ui/lib/workspace.js
@@ -89,6 +89,9 @@ class Workspace extends React.Component {
       if (event.key === "t") {
         this.props.dispatch({ type: "ToggleFileFinder" });
         event.stopPropagation();
+      } else if (event.key === "s") {
+        this.props.dispatch({ type: "SaveActiveBuffer" });
+        event.stopPropagation();
       }
     }
   }


### PR DESCRIPTION
This pull request introduces a new `SaveActiveBuffer` command that is dispatched when either pressing <kbd>⌘</kbd><kbd>S</kbd> or <kbd>Ctrl</kbd><kbd>S</kbd>. This new command applies to both local and remote workspaces, which in the latter case issues a save request to the host owning the buffer.

The save routine is carried out on a separate thread thanks to the introduction of `Buffer::snapshot`, which builds a read-only `Send`able clone of the current state of the buffer. Then, after successfully grabbing the file's lock in a background thread, the buffer's tree of visible fragments is traversed, encoded to UTF-8, and written to disk in a streaming fashion. 

At some point in the future we should handle different encodings, as well as coping with file corruption in the presence of an error in a graceful way.