### PR TITLE
Drop buffers that are not being used

### DIFF
--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -1,5 +1,5 @@
 use buffer::{self, Buffer, BufferId, Point, Selection, SelectionSetId};
-use futures::{Poll, Stream};
+use futures::{Future, Poll, Stream};
 use movement;
 use notify_cell::NotifyCell;
 use serde_json;
@@ -144,6 +144,10 @@ impl BufferView {
 
     fn scroll_bottom(&self) -> f64 {
         self.scroll_top() + self.height.unwrap_or(0.0)
+    }
+
+    pub fn save(&self) -> Option<Box<Future<Item = (), Error = buffer::Error>>> {
+        self.buffer.borrow().save()
     }
 
     pub fn edit(&mut self, text: &str) {

--- a/xray_core/src/project.rs
+++ b/xray_core/src/project.rs
@@ -11,7 +11,7 @@ use std::cmp;
 use std::collections::{BinaryHeap, HashMap};
 use std::error;
 use std::io;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use ForegroundExecutor;
 use IntoShared;
@@ -36,15 +36,16 @@ pub trait Project {
     ) -> (PathSearch, NotifyCellObserver<PathSearchStatus>);
 }
 
+struct BufferWeakSet {
+    buffers: Vec<Weak<RefCell<Buffer>>>,
+}
+
 pub struct LocalProject {
     file_provider: Rc<fs::FileProvider>,
     next_tree_id: TreeId,
     next_buffer_id: Rc<Cell<BufferId>>,
     trees: HashMap<TreeId, Rc<fs::LocalTree>>,
-    buffers: Rc<RefCell<HashMap<BufferId, Rc<RefCell<Buffer>>>>>,
-    files: Rc<RefCell<HashMap<fs::FileId, Box<fs::File>>>>,
-    buffers_by_file: Rc<RefCell<HashMap<fs::FileId, BufferId>>>,
-    files_by_buffer: Rc<RefCell<HashMap<BufferId, fs::FileId>>>,
+    buffers: Rc<RefCell<BufferWeakSet>>,
 }
 
 pub struct RemoteProject {
@@ -125,6 +126,50 @@ pub enum Error {
     UnexpectedResponse,
 }
 
+impl BufferWeakSet {
+    fn new() -> Self {
+        Self {
+            buffers: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, buffer: Buffer) -> Rc<RefCell<Buffer>> {
+        let buffer = Rc::new(RefCell::new(buffer));
+        self.buffers.push(Rc::downgrade(&buffer));
+        buffer
+    }
+
+    fn find_by_buffer_id(&mut self, buffer_id: BufferId) -> Option<Rc<RefCell<Buffer>>> {
+        let mut found_buffer = None;
+        self.buffers.retain(|buffer| {
+            if let Some(buffer) = buffer.upgrade() {
+                if buffer_id == buffer.borrow().id() {
+                    found_buffer = Some(buffer);
+                }
+                true
+            } else {
+                false
+            }
+        });
+        found_buffer
+    }
+
+    fn find_by_file_id(&mut self, file_id: fs::FileId) -> Option<Rc<RefCell<Buffer>>> {
+        let mut found_buffer = None;
+        self.buffers.retain(|buffer| {
+            if let Some(buffer) = buffer.upgrade() {
+                if buffer.borrow().file_id().map_or(false, |id| file_id == id) {
+                    found_buffer = Some(buffer);
+                }
+                true
+            } else {
+                false
+            }
+        });
+        found_buffer
+    }
+}
+
 impl LocalProject {
     pub fn new<T>(file_provider: Rc<fs::FileProvider>, trees: Vec<T>) -> Self
     where
@@ -135,10 +180,7 @@ impl LocalProject {
             next_tree_id: 0,
             next_buffer_id: Rc::new(Cell::new(0)),
             trees: HashMap::new(),
-            buffers: Rc::new(RefCell::new(HashMap::new())),
-            files: Rc::new(RefCell::new(HashMap::new())),
-            buffers_by_file: Rc::new(RefCell::new(HashMap::new())),
-            files_by_buffer: Rc::new(RefCell::new(HashMap::new())),
+            buffers: Rc::new(RefCell::new(BufferWeakSet::new())),
         };
         for tree in trees {
             project.add_tree(tree);
@@ -173,41 +215,27 @@ impl Project for LocalProject {
     ) -> Box<Future<Item = Rc<RefCell<Buffer>>, Error = Error>> {
         if let Some(absolute_path) = self.resolve_path(tree_id, relative_path) {
             let next_buffer_id_cell = self.next_buffer_id.clone();
-            let buffers_by_file = self.buffers_by_file.clone();
-            let files_by_buffer = self.files_by_buffer.clone();
             let buffers = self.buffers.clone();
-            let files = self.files.clone();
             Box::new(
                 self.file_provider
                     .open(&absolute_path)
                     .and_then(move |file| {
-                        let buffer_id = buffers_by_file.borrow().get(&file.id()).cloned();
-                        if let Some(ref buffer_id) = buffer_id {
-                            let buffer = buffers.borrow().get(buffer_id).unwrap().clone();
+                        let buffer = buffers.borrow_mut().find_by_file_id(file.id());
+                        if let Some(buffer) = buffer {
                             Box::new(future::ok(buffer))
                                 as Box<Future<Item = Rc<RefCell<Buffer>>, Error = io::Error>>
                         } else {
                             Box::new(file.read().and_then(move |content| {
-                                let buffer_id = buffers_by_file.borrow().get(&file.id()).cloned();
-                                if let Some(ref buffer_id) = buffer_id {
-                                    Ok(buffers.borrow().get(buffer_id).unwrap().clone())
+                                let buffer = buffers.borrow_mut().find_by_file_id(file.id());
+                                if let Some(buffer) = buffer {
+                                    Ok(buffer)
                                 } else {
                                     let buffer_id = next_buffer_id_cell.get();
                                     next_buffer_id_cell.set(next_buffer_id_cell.get() + 1);
                                     let mut buffer = Buffer::new(buffer_id);
                                     buffer.edit(&[0..0], content.as_str());
-                                    let buffer = buffer.into_shared();
-
-                                    let mut buffers = buffers.borrow_mut();
-                                    let mut files = files.borrow_mut();
-                                    let mut buffers_by_file = buffers_by_file.borrow_mut();
-                                    let mut files_by_buffer = files_by_buffer.borrow_mut();
-                                    buffers_by_file.insert(file.id(), buffer_id);
-                                    files_by_buffer.insert(buffer_id, file.id());
-                                    buffers.insert(buffer_id, buffer.clone());
-                                    files.insert(file.id(), file);
-
-                                    Ok(buffer)
+                                    buffer.set_file(file);
+                                    Ok(buffers.borrow_mut().insert(buffer))
                                 }
                             }))
                         }
@@ -226,9 +254,8 @@ impl Project for LocalProject {
         use futures::IntoFuture;
         Box::new(
             self.buffers
-                .borrow()
-                .get(&buffer_id)
-                .cloned()
+                .borrow_mut()
+                .find_by_buffer_id(buffer_id)
                 .ok_or(Error::BufferNotFound)
                 .into_future(),
         )
@@ -718,6 +745,33 @@ mod tests {
         let buffer_future_2 = project.open_path(tree_id, &relative_path);
         let (buffer_1, buffer_2) = buffer_future_1.join(buffer_future_2).wait().unwrap();
         assert!(Rc::ptr_eq(&buffer_1, &buffer_2));
+    }
+
+    #[test]
+    fn test_drop_buffer_rc() {
+        let file_provider = Rc::new(TestFileProvider::new());
+        let project = build_project(file_provider.clone());
+
+        let tree_id = 0;
+        let relative_path = cross_platform::Path::from("subdir-a/subdir-1/bar");
+        let absolute_path = project.resolve_path(tree_id, &relative_path).unwrap();
+        file_provider.write_sync(absolute_path, "disk");
+
+        let buffer_1 = project.open_path(tree_id, &relative_path).wait().unwrap();
+        buffer_1.borrow_mut().edit(&[0..4], "memory");
+        let buffer_2 = project.open_path(tree_id, &relative_path).wait().unwrap();
+        assert_eq!(buffer_2.borrow().to_string(), "memory");
+
+        // Dropping only one of the two strong references does not release the buffer.
+        drop(buffer_2);
+        let buffer_3 = project.open_path(tree_id, &relative_path).wait().unwrap();
+        assert_eq!(buffer_3.borrow().to_string(), "memory");
+
+        // Dropping all strong references causes the buffer to be released.
+        drop(buffer_1);
+        drop(buffer_3);
+        let buffer_4 = project.open_path(tree_id, &relative_path).wait().unwrap();
+        assert_eq!(buffer_4.borrow().to_string(), "disk");
     }
 
     #[test]

--- a/xray_core/src/rpc/mod.rs
+++ b/xray_core/src/rpc/mod.rs
@@ -6,7 +6,7 @@ pub use self::messages::{Response, ServiceId};
 use std::error;
 use std::fmt;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Error {
     ConnectionDropped,
     IoError(String),

--- a/xray_core/src/workspace.rs
+++ b/xray_core/src/workspace.rs
@@ -213,21 +213,18 @@ impl WorkspaceView {
 
     fn save_active_buffer(&self) {
         if let Some(ref active_buffer_view) = self.active_buffer_view {
-            if let Some(buffer_id) = active_buffer_view.map(|buffer_view| buffer_view.buffer_id()) {
-                let workspace = self.workspace.borrow();
+            active_buffer_view.map(|buffer_view| {
                 self.foreground
-                    .execute(Box::new(workspace.project().save_buffer(buffer_id).then(
-                        |result| {
-                            if let Err(error) = result {
-                                eprintln!("Error saving buffer {:?}", error);
-                                unimplemented!("Error handling for save_buffer: {:?}", error);
-                            } else {
-                                Ok(())
-                            }
-                        },
-                    )))
+                    .execute(Box::new(buffer_view.save().then(|result| {
+                        if let Err(error) = result {
+                            eprintln!("Error saving buffer {:?}", error);
+                            unimplemented!("Error handling for save_buffer: {:?}", error);
+                        } else {
+                            Ok(())
+                        }
+                    })))
                     .unwrap();
-            }
+            });
         }
     }
 }


### PR DESCRIPTION
Contrarily to the design I proposed in #84, this pull request takes a step back and moves ownership of `fs::File` down into `Buffer` so that buffers can be pruned more easily from `Project` when nobody is using them anymore.

My original rationale for storing `fs::File` (and a bi-directional mapping between files and buffers) in `Project` was that it felt awkward to clutter the buffer with more responsibilities than it already had. However, the key realization I had today was that `Project` isn't the actual owner of buffers at all. For example, when the last `BufferView` holding a particular buffer goes away, we want that buffer to be forgotten in `Project` as well. The same reasoning applies when all `buffer::rpc::Service` instances are dropped. This clearly indicated that the project should hold weak references to buffers instead.

The question still applies though: why moving the ownership of `fs::File` down into the buffer? The answer has to do with how we prune buffers from the project. Indeed, turning buffer into a `Weak` inside of `Project` allows it to let go of the buffer when the last real owner gets dropped. However, the same would not be true for `fs::File` if it lived inside of project. When presented with this challenge, I considered two choices:

* Find a way of signalling `Project` when dropping a buffer, so that the project could let go of all the state associated with that particular buffer. Circular references are always tricky to reason about, so this didn't really feel like a good solution.
* Move `fs::File` into `Buffer` and let the vector holding the list of weak references to buffers leak pointers for those buffers that are dropped.

I ended up going with the second approach, so that when the buffer is dropped by its last actual owner, it will also let go of the file (and its associated descriptor). All these details are cleanly abstracted away by the `BufferWeakSet` struct, which, when queried, cleans up all the weak references that are dangling.

Even though we will end up leaking a few pointers, this feels like the most elegant solution (among the ones I considered) given the set of constraints presented above.