### PR TITLE
Horizontal scrolling

### DIFF
--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -2695,7 +2695,7 @@ mod tests {
 
     #[test]
     fn test_longest_row_in_range() {
-        for seed in 0..10000 {
+        for seed in 0..100 {
             println!("{:?}", seed);
             let mut rng = StdRng::from_seed(&[seed]);
             let string = RandomCharIter(rng)

--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -730,6 +730,15 @@ impl Buffer {
         self.fragments.len::<Point>()
     }
 
+    pub fn line(&self, row: u32) -> Result<Vec<u16>, Error> {
+        let mut iterator = self.iter_starting_at_row(row).peekable();
+        if iterator.peek().is_none() {
+            Err(Error::OffsetOutOfRange)
+        } else {
+            Ok(iterator.take_while(|c| *c != u16::from(b'\n')).collect())
+        }
+    }
+
     pub fn snapshot(&self) -> BufferSnapshot {
         BufferSnapshot {
             fragments: self.fragments.clone(),

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -46,7 +46,6 @@ struct SelectionProps {
 enum BufferViewAction {
     UpdateScrollTop { delta: f64 },
     SetDimensions { width: u64, height: u64 },
-    SetLongestLineWidth { width: f64 },
     Edit { text: String },
     Backspace,
     Delete,
@@ -805,7 +804,7 @@ impl View for BufferView {
             Ok(BufferViewAction::SelectRight) => self.select_right(),
             Ok(BufferViewAction::AddSelectionAbove) => self.add_selection_above(),
             Ok(BufferViewAction::AddSelectionBelow) => self.add_selection_below(),
-            action @ _ => eprintln!("Unrecognized action {:?}", action),
+            Err(action) => eprintln!("Unrecognized action {:?}", action),
         }
     }
 }

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -25,7 +25,9 @@ pub struct BufferView {
     height: Option<f64>,
     width: Option<f64>,
     line_height: f64,
+    longest_line_width: Option<f64>,
     scroll_top: f64,
+    scroll_left: f64,
     vertical_margin: u32,
     pending_autoscroll: Option<AutoScrollRequest>,
     delegate: Option<WeakViewHandle<BufferViewDelegate>>,
@@ -44,7 +46,9 @@ struct SelectionProps {
 #[serde(tag = "type")]
 enum BufferViewAction {
     UpdateScrollTop { delta: f64 },
+    UpdateScrollLeft { delta: f64 },
     SetDimensions { width: u64, height: u64 },
+    SetLongestLineWidth { width: f64 },
     Edit { text: String },
     Backspace,
     Delete,
@@ -98,7 +102,9 @@ impl BufferView {
             height: None,
             width: None,
             line_height: 10.0,
+            longest_line_width: None,
             scroll_top: 0.0,
+            scroll_left: 0.0,
             vertical_margin: 2,
             pending_autoscroll: None,
             delegate,
@@ -129,6 +135,14 @@ impl BufferView {
         self
     }
 
+    pub fn set_longest_line_width(&mut self, width: f64) {
+        if self.longest_line_width.is_none() || width != self.longest_line_width.unwrap() {
+            self.longest_line_width = Some(width);
+            self.autoscroll_to_cursor(false);
+            self.updated();
+        }
+    }
+
     pub fn set_scroll_top(&mut self, scroll_top: f64) -> &mut Self {
         debug_assert!(scroll_top >= 0_f64);
         self.scroll_top = scroll_top;
@@ -144,6 +158,23 @@ impl BufferView {
 
     fn scroll_bottom(&self) -> f64 {
         self.scroll_top() + self.height.unwrap_or(0.0)
+    }
+
+    pub fn set_scroll_left(&mut self, scroll_left: f64) -> &mut Self {
+        debug_assert!(scroll_left >= 0_f64);
+        self.scroll_left = scroll_left;
+        self.pending_autoscroll = None;
+        self.updated();
+        self
+    }
+
+    fn scroll_left(&self) -> f64 {
+        if self.longest_line_width.is_some() && self.width.is_some() {
+            let max_scroll_left = (self.longest_line_width.unwrap() - self.width.unwrap()).max(0.0);
+            self.scroll_left.min(max_scroll_left)
+        } else {
+            self.scroll_left
+        }
     }
 
     pub fn save(&self) -> Option<Box<Future<Item = (), Error = buffer::Error>>> {
@@ -728,12 +759,24 @@ impl View for BufferView {
             lines.push(String::from_utf16_lossy(&cur_line));
         }
 
+        let mut longest_line = Vec::new();
+        for c in buffer.iter_starting_at_row(buffer.longest_row()) {
+            if c == u16::from(b'\n') {
+                break;
+            } else {
+                longest_line.push(c);
+            }
+        }
+
         json!({
             "first_visible_row": start.row,
             "lines": lines,
-            "scroll_top": self.scroll_top,
+            "longest_line": String::from_utf16_lossy(&longest_line),
+            "scroll_top": self.scroll_top(),
+            "scroll_left": self.scroll_left(),
             "height": self.height,
             "width": self.width,
+            "content_width": self.longest_line_width.or(self.width),
             "line_height": self.line_height,
             "selections": self.render_selections(start..end),
         })
@@ -748,9 +791,19 @@ impl View for BufferView {
                 }
                 self.set_scroll_top(scroll_top);
             }
+            Ok(BufferViewAction::UpdateScrollLeft { delta }) => {
+                let mut scroll_left = self.scroll_left() + delta;
+                if scroll_left < 0.0 {
+                    scroll_left = 0.0;
+                }
+                self.set_scroll_left(scroll_left);
+            }
             Ok(BufferViewAction::SetDimensions { width, height }) => {
                 self.set_width(width as f64);
                 self.set_height(height as f64);
+            }
+            Ok(BufferViewAction::SetLongestLineWidth { width }) => {
+                self.set_longest_line_width(width);
             }
             Ok(BufferViewAction::Edit { text }) => self.edit(text.as_str()),
             Ok(BufferViewAction::Backspace) => self.backspace(),

--- a/xray_core/src/tree.rs
+++ b/xray_core/src/tree.rs
@@ -276,7 +276,7 @@ impl<'a, T: Item> Tree<T> {
         }
     }
 
-    fn summary(&self) -> &T::Summary {
+    pub fn summary(&self) -> &T::Summary {
         match self.0.as_ref() {
             &Node::Internal { ref summary, .. } => summary,
             &Node::Leaf { ref summary, .. } => summary,

--- a/xray_ui/lib/text_editor/shaders.js
+++ b/xray_ui/lib/text_editor/shaders.js
@@ -5,7 +5,7 @@ exports.textBlendAttributes = {
   textColorRGBA: 3,
   atlasOrigin: 4,
   atlasSize: 5
-}
+};
 
 exports.textBlendVertex = `
   #version 300 es
@@ -18,12 +18,13 @@ exports.textBlendVertex = `
   layout (location = 5) in vec2 atlasSize;
 
   uniform vec2 viewportScale;
+  uniform float scrollLeft;
 
   flat out vec4 textColor;
   out vec2 atlasPosition;
 
   void main() {
-      vec2 targetPixelPosition = targetOrigin + unitQuadVertex * targetSize;
+      vec2 targetPixelPosition = (targetOrigin + unitQuadVertex * targetSize) - vec2(scrollLeft, 0.0);
       vec2 targetPosition = targetPixelPosition * viewportScale + vec2(-1.0, 1.0);
       gl_Position = vec4(targetPosition, 0.0, 1.0);
       textColor = textColorRGBA * vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 1.0);
@@ -32,7 +33,7 @@ exports.textBlendVertex = `
       textColor = textColorRGBA;
       atlasPosition = atlasOrigin + unitQuadVertex * atlasSize;
   }
-`.trim()
+`.trim();
 
 exports.textBlendPass1Fragment = `
   #version 300 es
@@ -51,7 +52,7 @@ exports.textBlendPass1Fragment = `
     vec3 correctedAtlasColor = mix(vec3(1.0) - atlasColor, sqrt(vec3(1.0) - atlasColor * atlasColor), textColorRGB);
     outColor = vec4(correctedAtlasColor, 1.0);
   }
-`.trim()
+`.trim();
 
 exports.textBlendPass2Fragment = `
   #version 300 es
@@ -71,14 +72,14 @@ exports.textBlendPass2Fragment = `
     vec3 adjustedForegroundColor = textColorRGB * correctedAtlasColor;
     outColor = vec4(adjustedForegroundColor, 1.0);
   }
-`.trim()
+`.trim();
 
 exports.solidAttributes = {
   unitQuadVertex: 0,
   targetOrigin: 1,
   targetSize: 2,
   colorRGBA: 3
-}
+};
 
 exports.solidVertex = `
   #version 300 es
@@ -90,14 +91,15 @@ exports.solidVertex = `
   flat out vec4 color;
 
   uniform vec2 viewportScale;
+  uniform float scrollLeft;
 
   void main() {
-      vec2 targetPixelPosition = targetOrigin + unitQuadVertex * targetSize;
+      vec2 targetPixelPosition = (targetOrigin + unitQuadVertex * targetSize) - vec2(scrollLeft, 0.0);
       vec2 targetPosition = targetPixelPosition * viewportScale + vec2(-1.0, 1.0);
       gl_Position = vec4(targetPosition, 0.0, 1.0);
       color = colorRGBA * vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 1.0);
   }
-`.trim()
+`.trim();
 
 exports.solidFragment = `
   #version 300 es
@@ -110,4 +112,4 @@ exports.solidFragment = `
   void main() {
     outColor = color;
   }
-`.trim()
+`.trim();

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -111,7 +111,7 @@ class TextEditor extends React.Component {
           paddingLeft: 5,
           scrollLeft: this.getScrollLeft(),
           height: this.props.height,
-          width: Math.max(this.props.width, this.getContentWidth()),
+          width: this.getScrollWidth(),
           selections: this.props.selections,
           firstVisibleRow: this.props.first_visible_row,
           lines: this.props.lines,
@@ -263,12 +263,17 @@ class TextEditor extends React.Component {
     if (contentWidth != null && this.props.width != null) {
       return Math.max(0, contentWidth - this.props.width);
     } else {
-      return Infinity;
+      return 0;
     }
   }
 
-  getMaxScrollRight() {
-    return this.getMaxScrollLeft() + this.props.width;
+  getScrollWidth() {
+    const contentWidth = this.getContentWidth();
+    if (contentWidth != null && this.props.width != null) {
+      return Math.max(contentWidth, this.props.width);
+    } else {
+      return 0;
+    }
   }
 
   getContentWidth() {

--- a/xray_ui/lib/text_editor/text_plane.js
+++ b/xray_ui/lib/text_editor/text_plane.js
@@ -62,6 +62,7 @@ class TextPlane extends React.Component {
       canvasWidth: this.props.width * window.devicePixelRatio,
       canvasHeight: this.props.height * window.devicePixelRatio,
       scrollTop: this.props.scrollTop,
+      scrollLeft: this.props.scrollLeft,
       paddingLeft: this.props.paddingLeft || 0,
       firstVisibleRow: this.props.firstVisibleRow,
       lines: this.props.lines,
@@ -71,6 +72,10 @@ class TextPlane extends React.Component {
       cursorColors,
       computedLineHeight
     });
+  }
+
+  measureLine(line) {
+    return this.renderer.measureLine(line);
   }
 }
 
@@ -137,13 +142,25 @@ class Renderer {
       this.textBlendPass1Program,
       "viewportScale"
     );
+    this.textBlendPass1ScrollLeftLocation = this.gl.getUniformLocation(
+      this.textBlendPass1Program,
+      "scrollLeft"
+    );
     this.textBlendPass2ViewportScaleLocation = this.gl.getUniformLocation(
       this.textBlendPass2Program,
       "viewportScale"
     );
+    this.textBlendPass2ScrollLeftLocation = this.gl.getUniformLocation(
+      this.textBlendPass2Program,
+      "scrollLeft"
+    );
     this.solidViewportScaleLocation = this.gl.getUniformLocation(
       this.solidProgram,
       "viewportScale"
+    );
+    this.solidScrollLeftLocation = this.gl.getUniformLocation(
+      this.solidProgram,
+      "scrollLeft"
     );
 
     this.createBuffers();
@@ -321,10 +338,21 @@ class Renderer {
     return vao;
   }
 
+  measureLine(line) {
+    let x = 0;
+    for (let i = 0; i < line.length; i++) {
+      const variantIndex = Math.round(x * SUBPIXEL_DIVISOR) % SUBPIXEL_DIVISOR;
+      const glyph = this.atlas.getGlyph(line[i], variantIndex);
+      x += glyph.subpixelWidth;
+    }
+    return x / this.style.dpiScale;
+  }
+
   draw({
     canvasHeight,
     canvasWidth,
     scrollTop,
+    scrollLeft,
     paddingLeft,
     firstVisibleRow,
     lines,
@@ -336,6 +364,7 @@ class Renderer {
     const { dpiScale } = this.style;
     const viewportScaleX = 2 / canvasWidth;
     const viewportScaleY = -2 / canvasHeight;
+    scrollLeft = Math.round(scrollLeft * dpiScale);
 
     const textColor = { r: 0, g: 0, b: 0, a: 255 };
     const cursorWidth = 2;
@@ -377,12 +406,27 @@ class Renderer {
     this.gl.clear(this.gl.COLOR_BUFFER_BIT);
     this.gl.viewport(0, 0, canvasWidth, canvasHeight);
 
-    this.drawSelections(selectionSolidCount, viewportScaleX, viewportScaleY);
-    this.drawText(glyphCount, viewportScaleX, viewportScaleY);
-    this.drawCursors(cursorSolidCount, viewportScaleX, viewportScaleY);
+    this.drawSelections(
+      selectionSolidCount,
+      scrollLeft,
+      viewportScaleX,
+      viewportScaleY
+    );
+    this.drawText(glyphCount, scrollLeft, viewportScaleX, viewportScaleY);
+    this.drawCursors(
+      cursorSolidCount,
+      scrollLeft,
+      viewportScaleX,
+      viewportScaleY
+    );
   }
 
-  drawSelections(selectionSolidCount, viewportScaleX, viewportScaleY) {
+  drawSelections(
+    selectionSolidCount,
+    scrollLeft,
+    viewportScaleX,
+    viewportScaleY
+  ) {
     this.gl.bindVertexArray(this.solidVAO);
     this.gl.enable(this.gl.BLEND);
     this.gl.useProgram(this.solidProgram);
@@ -391,6 +435,7 @@ class Renderer {
       viewportScaleX,
       viewportScaleY
     );
+    this.gl.uniform1f(this.solidScrollLeftLocation, scrollLeft);
     this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.solidInstancesBuffer);
     this.gl.bufferData(
       this.gl.ARRAY_BUFFER,
@@ -412,7 +457,7 @@ class Renderer {
     );
   }
 
-  drawText(glyphCount, viewportScaleX, viewportScaleY) {
+  drawText(glyphCount, scrollLeft, viewportScaleX, viewportScaleY) {
     this.gl.bindVertexArray(this.textBlendVAO);
     this.gl.enable(this.gl.BLEND);
     this.gl.useProgram(this.textBlendPass1Program);
@@ -421,6 +466,7 @@ class Renderer {
       viewportScaleX,
       viewportScaleY
     );
+    this.gl.uniform1f(this.textBlendPass1ScrollLeftLocation, scrollLeft);
     this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.glyphInstancesBuffer);
     this.gl.bufferData(
       this.gl.ARRAY_BUFFER,
@@ -453,6 +499,7 @@ class Renderer {
       viewportScaleX,
       viewportScaleY
     );
+    this.gl.uniform1f(this.textBlendPass2ScrollLeftLocation, scrollLeft);
     this.gl.drawElementsInstanced(
       this.gl.TRIANGLES,
       6,
@@ -462,7 +509,7 @@ class Renderer {
     );
   }
 
-  drawCursors(cursorSolidCount, viewportScaleX, viewportScaleY) {
+  drawCursors(cursorSolidCount, scrollLeft, viewportScaleX, viewportScaleY) {
     this.gl.bindVertexArray(this.solidVAO);
     this.gl.disable(this.gl.BLEND);
     this.gl.useProgram(this.solidProgram);
@@ -471,6 +518,7 @@ class Renderer {
       viewportScaleX,
       viewportScaleY
     );
+    this.gl.uniform1f(this.solidScrollLeftLocation, scrollLeft);
     this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.solidInstancesBuffer);
     this.gl.bufferData(
       this.gl.ARRAY_BUFFER,

--- a/xray_ui/lib/text_editor/text_plane.js
+++ b/xray_ui/lib/text_editor/text_plane.js
@@ -77,6 +77,10 @@ class TextPlane extends React.Component {
   measureLine(line) {
     return this.renderer.measureLine(line);
   }
+
+  isReady() {
+    return this.renderer != null;
+  }
 }
 
 TextPlane.contextTypes = {

--- a/xray_ui/lib/text_editor/text_plane.js
+++ b/xray_ui/lib/text_editor/text_plane.js
@@ -74,8 +74,8 @@ class TextPlane extends React.Component {
     });
   }
 
-  measureLine(line) {
-    return this.renderer.measureLine(line);
+  measureLine(line, column) {
+    return this.renderer.measureLine(line, column);
   }
 
   isReady() {
@@ -342,9 +342,9 @@ class Renderer {
     return vao;
   }
 
-  measureLine(line) {
+  measureLine(line, column = line.length) {
     let x = 0;
-    for (let i = 0; i < line.length; i++) {
+    for (let i = 0; i < column; i++) {
       const variantIndex = Math.round(x * SUBPIXEL_DIVISOR) % SUBPIXEL_DIVISOR;
       const glyph = this.atlas.getGlyph(line[i], variantIndex);
       x += glyph.subpixelWidth;


### PR DESCRIPTION
This pull request adds the ability to scroll the editor horizontally via the mouse wheel, as well as autoscrolling when the cursor moves. This feature took a couple of days to get implemented because we wanted to find a way of efficiently maintaining the longest line in a given range. This will not only be useful for horizontal scrolling, but will be reused when we will introduce a "display map" to handle folds and soft-wraps. A few highlights related to the proposed changes:

* Each `Insertion` maintains a line index that is specifically designed to efficiently answer the following queries:
  * Given a 1d offset, return its 2d position.
  * Given a 2d position, return its 1d offset.
  * Given an offset range, return the longest row in that range
* The line index is a binary tree represented as a densely packed array. To achieve this layout we use a linear algorithm that, instead of trying to recursively divide the sequence in two evenly sized subsequences, ensures that all the levels of the tree are full (except the last one) and filled from left to right (i.e., a complete binary tree).
* Horizontal scrolling is entirely handled in JS. This is somewhat unfortunate and goes against our principle of pushing as much logic as possible down into the Rust core. However, until we replace our JS text layout engine with a more sophisticated one entirely implemented in native code, this minimizes the coordination that would need to happen between Rust and JS in order to retrieve layout information, measurements, etc.

/cc: @nathansobo 