### PR TITLE
Show line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Once we get the basic collaboration experience down, we'll be looking to expand 
 * [x] Key bindings system
 * [x] Horizontal scrolling
 * [ ] Word- and line-based cursor movements
-* [ ] Gutter with line numbers
+* [x] Gutter with line numbers
 * [ ] Mouse interaction
 * [ ] Workspace tabs
 * [ ] Split panes

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -766,6 +766,7 @@ impl View for BufferView {
 
         json!({
             "first_visible_row": start.row,
+            "total_row_count": buffer.max_point().row + 1,
             "lines": lines,
             "longest_line": longest_line,
             "scroll_top": self.scroll_top(),


### PR DESCRIPTION
This pull request introduces a gutter into the editor in order to show line numbers.
<img width="912" alt="screen shot 2018-05-28 at 11 35 02" src="https://user-images.githubusercontent.com/482957/40608256-2d9a48ec-626b-11e8-8706-2ad19b294251.png">

We simply added an extra pass to the `draw` routine which clears out the rectangle where the gutter will be displayed in and draws line number glyphs on top of it. To achieve this were able to reuse the existing solid and text shaders.