### PR TITLE
Introduce word- and line-based cursor movements

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ Once we get the basic collaboration experience down, we'll be looking to expand 
   * [x] Move To End Of Word
   * [ ] Move To Top
   * [ ] Select To Beginning Of Line
-  * [ ] Select To Beginning Of Word
+  * [x] Select To Beginning Of Word
   * [ ] Select To Bottom
   * [ ] Select To End Of Line
-  * [ ] Select To End Of Word
+  * [x] Select To End Of Word
   * [ ] Select To Top
 * [x] Gutter with line numbers
 * [ ] Mouse interaction

--- a/README.md
+++ b/README.md
@@ -182,16 +182,16 @@ Once we get the basic collaboration experience down, we'll be looking to expand 
 * [x] Key bindings system
 * [x] Horizontal scrolling
 * [ ] Word- and line-based cursor movements
-  * [ ] Move To Beginning Of Line
+  * [x] Move To Beginning Of Line
   * [x] Move To Beginning Of Word
   * [ ] Move To Bottom
-  * [ ] Move To End Of Line
+  * [x] Move To End Of Line
   * [x] Move To End Of Word
   * [ ] Move To Top
-  * [ ] Select To Beginning Of Line
+  * [x] Select To Beginning Of Line
   * [x] Select To Beginning Of Word
   * [ ] Select To Bottom
-  * [ ] Select To End Of Line
+  * [x] Select To End Of Line
   * [x] Select To End Of Word
   * [ ] Select To Top
 * [x] Gutter with line numbers

--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ Once we get the basic collaboration experience down, we'll be looking to expand 
 * [x] Horizontal scrolling
 * [ ] Word- and line-based cursor movements
   * [ ] Move To Beginning Of Line
-  * [ ] Move To Beginning Of Word
+  * [x] Move To Beginning Of Word
   * [ ] Move To Bottom
   * [ ] Move To End Of Line
-  * [ ] Move To End Of Word
+  * [x] Move To End Of Word
   * [ ] Move To Top
   * [ ] Select To Beginning Of Line
   * [ ] Select To Beginning Of Word

--- a/README.md
+++ b/README.md
@@ -181,19 +181,7 @@ Once we get the basic collaboration experience down, we'll be looking to expand 
 
 * [x] Key bindings system
 * [x] Horizontal scrolling
-* [ ] Word- and line-based cursor movements
-  * [x] Move To Beginning Of Line
-  * [x] Move To Beginning Of Word
-  * [ ] Move To Bottom
-  * [x] Move To End Of Line
-  * [x] Move To End Of Word
-  * [ ] Move To Top
-  * [x] Select To Beginning Of Line
-  * [x] Select To Beginning Of Word
-  * [ ] Select To Bottom
-  * [x] Select To End Of Line
-  * [x] Select To End Of Word
-  * [ ] Select To Top
+* [x] Word- and line-based cursor movements
 * [x] Gutter with line numbers
 * [ ] Mouse interaction
 * [ ] Workspace tabs

--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ Once we get the basic collaboration experience down, we'll be looking to expand 
 * [x] Key bindings system
 * [x] Horizontal scrolling
 * [ ] Word- and line-based cursor movements
+  * [ ] Move To Beginning Of Line
+  * [ ] Move To Beginning Of Word
+  * [ ] Move To Bottom
+  * [ ] Move To End Of Line
+  * [ ] Move To End Of Word
+  * [ ] Move To Top
+  * [ ] Select To Beginning Of Line
+  * [ ] Select To Beginning Of Word
+  * [ ] Select To Bottom
+  * [ ] Select To End Of Line
+  * [ ] Select To End Of Word
+  * [ ] Select To Top
 * [x] Gutter with line numbers
 * [ ] Mouse interaction
 * [ ] Workspace tabs

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -719,7 +719,7 @@ impl View for BufferView {
         let mut lines = Vec::new();
         let mut cur_line = Vec::new();
         let mut cur_row = start.row;
-        for c in buffer.iter_starting_at_row(start.row) {
+        for c in buffer.iter_starting_at_point(start) {
             if c == u16::from(b'\n') {
                 lines.push(String::from_utf16_lossy(&cur_line));
                 cur_line = Vec::new();

--- a/xray_core/src/movement.rs
+++ b/xray_core/src/movement.rs
@@ -77,3 +77,13 @@ pub fn end_of_word(buffer: &Buffer, mut point: Point) -> Point {
     }
     point
 }
+
+pub fn beginning_of_line(mut point: Point) -> Point {
+    point.column = 0;
+    point
+}
+
+pub fn end_of_line(buffer: &Buffer, mut point: Point) -> Point {
+    point.column = buffer.len_for_row(point.row).unwrap();
+    point
+}

--- a/xray_core/src/movement.rs
+++ b/xray_core/src/movement.rs
@@ -1,5 +1,6 @@
-use std::cmp;
 use buffer::{Buffer, Point};
+use std::char::decode_utf16;
+use std::cmp;
 
 pub fn left(buffer: &Buffer, mut point: Point) -> Point {
     if point.column > 0 {
@@ -45,4 +46,34 @@ pub fn down(buffer: &Buffer, mut point: Point, goal_column: Option<u32>) -> (Poi
     }
 
     (point, goal_column)
+}
+
+pub fn beginning_of_word(buffer: &Buffer, mut point: Point) -> Point {
+    // TODO: remove this once the iterator returns char instances.
+    let mut iter = decode_utf16(buffer.backward_iter_starting_at_point(point)).map(|c| c.unwrap());
+    let skip_alphanumeric = iter.next().map_or(false, |c| c.is_alphanumeric());
+    point = left(buffer, point);
+    for character in iter {
+        if skip_alphanumeric == character.is_alphanumeric() {
+            point = left(buffer, point);
+        } else {
+            break;
+        }
+    }
+    point
+}
+
+pub fn end_of_word(buffer: &Buffer, mut point: Point) -> Point {
+    // TODO: remove this once the iterator returns char instances.
+    let mut iter = decode_utf16(buffer.iter_starting_at_point(point)).map(|c| c.unwrap());
+    let skip_alphanumeric = iter.next().map_or(false, |c| c.is_alphanumeric());
+    point = right(buffer, point);
+    for character in iter {
+        if skip_alphanumeric == character.is_alphanumeric() {
+            point = right(buffer, point);
+        } else {
+            break;
+        }
+    }
+    point
 }

--- a/xray_ui/lib/app.js
+++ b/xray_ui/lib/app.js
@@ -47,6 +47,7 @@ const keyBindings = [
   { key: "left", context: "TextEditor", action: "MoveLeft" },
   { key: "right", context: "TextEditor", action: "MoveRight" },
   { key: "alt-left", context: "TextEditor", action: "MoveToBeginningOfWord" },
+  { key: "alt-right", context: "TextEditor", action: "MoveToEndOfWord" },
   { key: "backspace", context: "TextEditor", action: "Backspace" },
   { key: "delete", context: "TextEditor", action: "Delete" }
 ];

--- a/xray_ui/lib/app.js
+++ b/xray_ui/lib/app.js
@@ -58,6 +58,8 @@ const keyBindings = [
   { key: "right", context: "TextEditor", action: "MoveRight" },
   { key: "alt-left", context: "TextEditor", action: "MoveToBeginningOfWord" },
   { key: "alt-right", context: "TextEditor", action: "MoveToEndOfWord" },
+  { key: "cmd-left", context: "TextEditor", action: "MoveToBeginningOfLine" },
+  { key: "cmd-right", context: "TextEditor", action: "MoveToEndOfLine" },
   { key: "backspace", context: "TextEditor", action: "Backspace" },
   { key: "delete", context: "TextEditor", action: "Delete" }
 ];

--- a/xray_ui/lib/app.js
+++ b/xray_ui/lib/app.js
@@ -46,6 +46,7 @@ const keyBindings = [
   { key: "down", context: "TextEditor", action: "MoveDown" },
   { key: "left", context: "TextEditor", action: "MoveLeft" },
   { key: "right", context: "TextEditor", action: "MoveRight" },
+  { key: "alt-left", context: "TextEditor", action: "MoveToBeginningOfWord" },
   { key: "backspace", context: "TextEditor", action: "Backspace" },
   { key: "delete", context: "TextEditor", action: "Delete" }
 ];

--- a/xray_ui/lib/app.js
+++ b/xray_ui/lib/app.js
@@ -42,6 +42,16 @@ const keyBindings = [
   { key: "shift-down", context: "TextEditor", action: "SelectDown" },
   { key: "shift-left", context: "TextEditor", action: "SelectLeft" },
   { key: "shift-right", context: "TextEditor", action: "SelectRight" },
+  {
+    key: "alt-shift-left",
+    context: "TextEditor",
+    action: "SelectToBeginningOfWord"
+  },
+  {
+    key: "alt-shift-right",
+    context: "TextEditor",
+    action: "SelectToEndOfWord"
+  },
   { key: "up", context: "TextEditor", action: "MoveUp" },
   { key: "down", context: "TextEditor", action: "MoveDown" },
   { key: "left", context: "TextEditor", action: "MoveLeft" },

--- a/xray_ui/lib/app.js
+++ b/xray_ui/lib/app.js
@@ -52,6 +52,16 @@ const keyBindings = [
     context: "TextEditor",
     action: "SelectToEndOfWord"
   },
+  {
+    key: "shift-cmd-left",
+    context: "TextEditor",
+    action: "SelectToBeginningOfLine"
+  },
+  {
+    key: "shift-cmd-right",
+    context: "TextEditor",
+    action: "SelectToEndOfLine"
+  },
   { key: "up", context: "TextEditor", action: "MoveUp" },
   { key: "down", context: "TextEditor", action: "MoveDown" },
   { key: "left", context: "TextEditor", action: "MoveLeft" },

--- a/xray_ui/lib/app.js
+++ b/xray_ui/lib/app.js
@@ -62,6 +62,16 @@ const keyBindings = [
     context: "TextEditor",
     action: "SelectToEndOfLine"
   },
+  {
+    key: "shift-cmd-up",
+    context: "TextEditor",
+    action: "SelectToTop"
+  },
+  {
+    key: "shift-cmd-down",
+    context: "TextEditor",
+    action: "SelectToBottom"
+  },
   { key: "up", context: "TextEditor", action: "MoveUp" },
   { key: "down", context: "TextEditor", action: "MoveDown" },
   { key: "left", context: "TextEditor", action: "MoveLeft" },
@@ -70,6 +80,8 @@ const keyBindings = [
   { key: "alt-right", context: "TextEditor", action: "MoveToEndOfWord" },
   { key: "cmd-left", context: "TextEditor", action: "MoveToBeginningOfLine" },
   { key: "cmd-right", context: "TextEditor", action: "MoveToEndOfLine" },
+  { key: "cmd-up", context: "TextEditor", action: "MoveToTop" },
+  { key: "cmd-down", context: "TextEditor", action: "MoveToBottom" },
   { key: "backspace", context: "TextEditor", action: "Backspace" },
   { key: "delete", context: "TextEditor", action: "Delete" }
 ];

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -150,6 +150,14 @@ class TextEditor extends React.Component {
         type: "SelectToEndOfWord",
         onWillDispatch: this.pauseCursorBlinking
       }),
+      $(Action, {
+        type: "SelectToBeginningOfLine",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
+        type: "SelectToEndOfLine",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
       $(Action, { type: "MoveUp", onWillDispatch: this.pauseCursorBlinking }),
       $(Action, { type: "MoveDown", onWillDispatch: this.pauseCursorBlinking }),
       $(Action, { type: "MoveLeft", onWillDispatch: this.pauseCursorBlinking }),

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -158,6 +158,14 @@ class TextEditor extends React.Component {
         type: "SelectToEndOfLine",
         onWillDispatch: this.pauseCursorBlinking
       }),
+      $(Action, {
+        type: "SelectToTop",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
+        type: "SelectToBottom",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
       $(Action, { type: "MoveUp", onWillDispatch: this.pauseCursorBlinking }),
       $(Action, { type: "MoveDown", onWillDispatch: this.pauseCursorBlinking }),
       $(Action, { type: "MoveLeft", onWillDispatch: this.pauseCursorBlinking }),
@@ -179,6 +187,14 @@ class TextEditor extends React.Component {
       }),
       $(Action, {
         type: "MoveToEndOfLine",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
+        type: "MoveToTop",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
+        type: "MoveToBottom",
         onWillDispatch: this.pauseCursorBlinking
       }),
       $(Action, {

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -142,6 +142,14 @@ class TextEditor extends React.Component {
         type: "SelectRight",
         onWillDispatch: this.pauseCursorBlinking
       }),
+      $(Action, {
+        type: "SelectToBeginningOfWord",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
+        type: "SelectToEndOfWord",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
       $(Action, { type: "MoveUp", onWillDispatch: this.pauseCursorBlinking }),
       $(Action, { type: "MoveDown", onWillDispatch: this.pauseCursorBlinking }),
       $(Action, { type: "MoveLeft", onWillDispatch: this.pauseCursorBlinking }),

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -154,6 +154,10 @@ class TextEditor extends React.Component {
         onWillDispatch: this.pauseCursorBlinking
       }),
       $(Action, {
+        type: "MoveToEndOfWord",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
         type: "Backspace",
         onWillDispatch: this.pauseCursorBlinking
       }),

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -150,6 +150,10 @@ class TextEditor extends React.Component {
         onWillDispatch: this.pauseCursorBlinking
       }),
       $(Action, {
+        type: "MoveToBeginningOfWord",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
         type: "Backspace",
         onWillDispatch: this.pauseCursorBlinking
       }),

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -166,6 +166,14 @@ class TextEditor extends React.Component {
         onWillDispatch: this.pauseCursorBlinking
       }),
       $(Action, {
+        type: "MoveToBeginningOfLine",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
+        type: "MoveToEndOfLine",
+        onWillDispatch: this.pauseCursorBlinking
+      }),
+      $(Action, {
         type: "Backspace",
         onWillDispatch: this.pauseCursorBlinking
       }),


### PR DESCRIPTION
As the title says, this pull request introduces several word- and line-based cursor movements that are necessary for a basic editing experience. More specifically, this is the list of commands that will be available after this pull request:

* Move To Beginning Of Line
* Move To Beginning Of Word
* Move To Bottom
* Move To End Of Line
* Move To End Of Word
* Move To Top
* Select To Beginning Of Line
* Select To Beginning Of Word
* Select To Bottom
* Select To End Of Line
* Select To End Of Word
* Select To Top

[xray_ui/lib/app.js](https://github.com/atom/xray/compare/word-line-cursor-movements?expand=1#diff-eef0483debc728c2f3f021eba42e84ff) exposes which keymaps these commands are bound to. I have borrowed the mappings from from Atom's macOS keymap file, but creating more bindings to other key combinations (e.g., for other platforms) should be trivial.

/cc: @nathansobo 