### PR TITLE
Add basic mouse interaction

### DIFF
--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -13,7 +13,8 @@ const CURSOR_BLINK_PERIOD = 800;
 const Root = styled("div", {
   width: "100%",
   height: "100%",
-  overflow: "hidden"
+  overflow: "hidden",
+  cursor: "text"
 });
 
 class TextEditor extends React.Component {

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -209,33 +209,60 @@ class TextEditor extends React.Component {
     );
   }
 
-  handleMouseDown({ clientX, clientY }) {
+  handleMouseDown(event) {
     if (this.canUseTextPlane()) {
-      const { scroll_top, line_height, first_visible_row, lines } = this.props;
-      const { scrollLeft } = this.state;
-      const targetX =
-        clientX - this.element.offsetLeft + scrollLeft - this.getGutterWidth();
-      const targetY = clientY - this.element.offsetTop + scroll_top;
-      const row = Math.max(0, Math.floor(targetY / line_height));
-      const line = lines[row - first_visible_row];
-      if (line != null) {
-        const glyphWidths = this.textPlane.layoutLine(line);
-        let column = 0;
-        let x = 0;
-        while (x < targetX && column < line.length) {
-          const glyphWidth = glyphWidths[column];
-          if (targetX > x + glyphWidth / 2) {
-            column++;
-            x += glyphWidth;
-          } else {
-            break;
-          }
-        }
-
-        this.pauseCursorBlinking();
-        this.props.dispatch({ type: "SetCursorPosition", row, column });
+      this.handleClick(event);
+      switch (event.detail) {
+        case 2:
+          this.handleDoubleClick();
+          break;
+        case 3:
+          this.handleTripleClick();
+          break;
       }
     }
+  }
+
+  handleClick({ clientX, clientY }) {
+    const { scroll_top, line_height, first_visible_row, lines } = this.props;
+    const { scrollLeft } = this.state;
+    const targetX =
+      clientX - this.element.offsetLeft + scrollLeft - this.getGutterWidth();
+    const targetY = clientY - this.element.offsetTop + scroll_top;
+    const row = Math.max(0, Math.floor(targetY / line_height));
+    const line = lines[row - first_visible_row];
+    if (line != null) {
+      const glyphWidths = this.textPlane.layoutLine(line);
+      let column = 0;
+      let x = 0;
+      while (x < targetX && column < line.length) {
+        const glyphWidth = glyphWidths[column];
+        if (targetX > x + glyphWidth / 2) {
+          column++;
+          x += glyphWidth;
+        } else {
+          break;
+        }
+      }
+
+      this.pauseCursorBlinking();
+      this.props.dispatch({
+        type: "SetCursorPosition",
+        row,
+        column,
+        autoscroll: false
+      });
+    }
+  }
+
+  handleDoubleClick() {
+    this.pauseCursorBlinking();
+    this.props.dispatch({ type: "SelectWord" });
+  }
+
+  handleTripleClick() {
+    this.pauseCursorBlinking();
+    this.props.dispatch({ type: "SelectLine" });
   }
 
   handleMouseWheel(event) {


### PR DESCRIPTION
This pull request adds basic mouse interactions to the editor. More specifically, after the proposed changes, users will be able to:

* Move the cursor using the mouse
* Double click to select the word under the mouse
* Triple click to select the line under the mouse

![mouse-interaction](https://user-images.githubusercontent.com/482957/40773460-3e40eb10-64c3-11e8-9126-e0b9f0d40ac6.gif)

/cc: @nathansobo 