### PR TITLE
Don't cache cargo on Travis and install `wasm-bindgen-cli` on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,8 @@ before_install:
 script: script/cibuild
 
 cache:
-  cargo: true
+  cargo: false
   yarn: true
-
-branches:
-  only:
-    - master
 
 notifications:
   email:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Later versions may work, but you should ideally run the build with the same vers
 
 #### Install Rust
 
-You can install Rust via [`rustup`](https://www.rustup.rs/). We currently require building on the nightly channel in order to use `wasm_bindgen` for browser support.
+You can install Rust via [`rustup`](https://www.rustup.rs/). We currently require building on the nightly channel in order to use `wasm_bindgen` for browser support. To accomplish this, run `rustup default nightly`. Finally, you'll also need to install `wasm-bindgen-cli` which you can do by running `cargo install wasm-bindgen-cli`.
 
 #### Install Yarn
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Xray
 
-[![Build Status](https://travis-ci.org/atom/xray.svg?branch=master)](https://travis-ci.org/atom/xray)
+[![Build Status](https://travis-ci.org/pranaygp/xray.svg?branch=master)](https://travis-ci.org/pranaygp/xray)
 
 Xray is an experimental Electron-based text editor informed by what we've learned in the four years since the launch of Atom. In the short term, this project is a testbed for rapidly iterating on several radical ideas without risking the stability of Atom. The longer term future of the code in this repository will become clearer after a few months of progress. For now, our primary goal is to iterate rapidly and learn as much as possible.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Xray
 
-[![Build Status](https://travis-ci.org/pranaygp/xray.svg?branch=master)](https://travis-ci.org/pranaygp/xray)
+[![Build Status](https://travis-ci.org/atom/xray.svg?branch=master)](https://travis-ci.org/atom/xray)
 
 Xray is an experimental Electron-based text editor informed by what we've learned in the four years since the launch of Atom. In the short term, this project is a testbed for rapidly iterating on several radical ideas without risking the stability of Atom. The longer term future of the code in this repository will become clearer after a few months of progress. For now, our primary goal is to iterate rapidly and learn as much as possible.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Xray
+# Xray 
 
 [![Build Status](https://travis-ci.org/atom/xray.svg?branch=master)](https://travis-ci.org/atom/xray)
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -2,6 +2,7 @@
 
 set -e
 
+cargo install wasm-bindgen-cli
 script/build
 script/test
 script/bench


### PR DESCRIPTION
I ran into some issues when building this locally and think it might have to do with  a broken `wasm-bindgen` nightly build (look at https://github.com/rustwasm/wasm-bindgen/issues/235) but was confused how the tests worked in CI.

~This is just a PR to test if it's still broken in CI (by making trivial code changes to trigger CI)~

I discovered that, if you run the current master according to the steps, it will actually fail building but only worked in CI because of Travis' caching. For more complete tests and to avoid this scenario where it works on CI but not in a new setup, I think we should disable caching on CI (for now)