### PR TITLE
Refactor to use while-let in buffer.integrate_edit()

### DIFF
--- a/xray_core/src/buffer.rs
+++ b/xray_core/src/buffer.rs
@@ -1012,9 +1012,7 @@ impl Buffer {
             cursor.next();
         }
 
-        while cursor.item().is_some() {
-            let fragment = cursor.item().unwrap();
-
+        while let Some(fragment) = cursor.item() {
             if new_text.is_none() && fragment.id > end_fragment_id {
                 break;
             }


### PR DESCRIPTION
This really is a minor refactor but I came a cross it while looking through the code and thought I may as well just submit it.

**What**
Refactor to use [while-let](https://doc.rust-lang.org/rust-by-example/flow_control/while_let.html) syntax instead of a manuell check and assignment

**Why**
- Replaces two `item()` calls with just one
- Gets rid of an `.unwrap()` call
- More idiomatic code