### PR TITLE
Improve cursor movement when inserting

### DIFF
--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -195,6 +195,7 @@ impl BufferView {
             let mut buffer = self.buffer.borrow_mut();
             buffer.edit(&offset_ranges, text);
 
+            let text_char_length = text.chars().count();
             let mut delta = 0_isize;
             buffer
                 .mutate_selections(self.selection_set_id, |buffer, selections| {
@@ -204,10 +205,10 @@ impl BufferView {
                             let start = range.start as isize;
                             let end = range.end as isize;
                             let anchor = buffer
-                                .anchor_before_offset((start + delta) as usize + text.len())
+                                .anchor_before_offset((start + delta) as usize + text_char_length)
                                 .unwrap();
                             let deleted_count = end - start;
-                            delta += text.len() as isize - deleted_count;
+                            delta += text_char_length as isize - deleted_count;
                             Selection {
                                 start: anchor.clone(),
                                 end: anchor,

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -1783,6 +1783,23 @@ mod tests {
                 selection((0, 6), (0, 6)),
             ]
         );
+
+        let mut editor = BufferView::new(Rc::new(RefCell::new(Buffer::new(0))), 0, None);
+        editor
+            .buffer
+            .borrow_mut()
+            .edit(&[0..0], "123");
+
+        editor.edit("ä");
+        editor.edit("a");
+
+        assert_eq!(editor.buffer.borrow().to_string(), "äa123");
+        assert_eq!(
+            render_selections(&editor),
+            vec![
+                selection((0, 2), (0, 2)),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Attempts to fix #113

Still not perfect: the rust [`char`](https://doc.rust-lang.org/std/char/index.html) returned by `chars()` represent "Unicode Scalar Values" which may not be considered characters 1 to 1:

> It's important to remember that char represents a Unicode Scalar Value, and may not match your idea of what a 'character' is. Iteration over grapheme clusters may be what you actually want.

https://stackoverflow.com/questions/46290655/get-the-string-length-in-characters-in-rust

See this [demo in the rust play ground](http://play.rust-lang.org/?gist=924146e1ba523a96be5417a96e23e58a)

Xray currently displays:
<img width="873" alt="bildschirmfoto 2018-07-17 um 15 34 39" src="https://user-images.githubusercontent.com/10676525/42820694-0a280618-89d7-11e8-8e7f-9b576c2caf79.png">

The problem seems to be that the perceived length of a string can't really be determined by the string in isolation. A good example is the `👍🏽` string in the demo: in the editor it is displayed as two separate characters (the skip tone modifier and the actual emoji) but in the output it is displayed as one (the emoji with changed skin tone). As a user I would expect the cursor to move two characters in the first case but one in the second.

However since Xray seems to be unable to display complex multibyte unicode characters anyway I'd consider this change to be sufficient for now.