### PR TITLE
Add open file information to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ That assumes you built with `--release`. To run the debug version, use `xray_deb
 XRAY_SRC_PATH=. script/xray_debug .
 ```
 
+Once a blank window has opened, press <kbd>cmd-t</kbd> to open the file selection menu. Search for a file, and press <kbd>enter</kbd> to open it. The contents of the file should appear in the window. If something does not go as expected, check the dev tools (<kbd>cmd-shift-i</kbd>) for errors.
+
 ## Running tests and benchmarks
 
 * All tests: `script/test`


### PR DESCRIPTION
I was getting a blank window, and familiar shortcuts weren't working (I use <kbd>cmd-t</kbd> for something else in Atom). 

This change should unambiguously point out what to expect when launching, and how to open a file.