### PR TITLE
Fix web and TS building

### DIFF
--- a/memo_js/.npmignore
+++ b/memo_js/.npmignore
@@ -3,4 +3,3 @@ test
 Cargo.toml
 README.md
 node_modules
-webpack.config.js

--- a/memo_js/.npmignore
+++ b/memo_js/.npmignore
@@ -3,3 +3,4 @@ test
 Cargo.toml
 README.md
 node_modules
+webpack.config.js

--- a/memo_js/package.json
+++ b/memo_js/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@atom/memo",
   "version": "0.1.2",
-  "main": "dist/index.js",
-  "browser": "src/index.js",
+  "main": "dist/index.node.js",
+  "browser": "dist/index.web.js",
   "scripts": {
     "prepublishOnly": "script/build",
     "test": "mocha --ui=tdd test"

--- a/memo_js/package.json
+++ b/memo_js/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.2",
   "main": "dist/index.node.js",
   "browser": "dist/index.web.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prepublishOnly": "script/build",
     "test": "mocha --ui=tdd test"

--- a/memo_js/test/tests.js
+++ b/memo_js/test/tests.js
@@ -1,4 +1,4 @@
-const memo = require("../dist");
+const memo = require("../dist/index.node.js");
 const assert = require("assert");
 
 suite("WorkTree", () => {

--- a/memo_js/tsconfig.json
+++ b/memo_js/tsconfig.json
@@ -3,6 +3,8 @@
     "outDir": "./dist/",
     "noImplicitAny": true,
     "module": "esnext",
+    "declarationMap": true,
+    "declaration": true,
     "lib": ["es2015"]
   }
 }

--- a/memo_js/webpack.config.js
+++ b/memo_js/webpack.config.js
@@ -1,6 +1,6 @@
 var path = require("path");
 
-module.exports = {
+const baseConfig = {
   entry: "./src/index.ts",
   module: {
     rules: [
@@ -16,9 +16,27 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, "dist"),
-    filename: "index.js",
     library: "memo",
     libraryTarget: "umd"
-  },
-  target: "node"
+  }
 };
+
+const nodeConfig = {
+  ...baseConfig,
+  target: "node",
+  output: {
+    ...baseConfig.output,
+    filename: "index.node.js"
+  }
+};
+
+const webConfig = {
+  ...baseConfig,
+  target: "web",
+  output: {
+    ...baseConfig.output,
+    filename: "index.web.js"
+  }
+};
+
+module.exports = [nodeConfig, webConfig];


### PR DESCRIPTION
This replaces #139 

1. Generate and point to the TypeScript declaration and map file.
1. Build for both web and node.
1. Point the web to its build.