### PR TITLE
Super duper TS

### DIFF
--- a/memo_js/README.md
+++ b/memo_js/README.md
@@ -57,7 +57,7 @@ If you have not finished populating the base entries via `appendBaseEntries`, so
 To list the work tree's current paths, call `entries`. This will return an array of entries arranged in a depth-first order, similar to the argument to `appendBaseEntries`. For example, the base entries populated above could be retrieved as follows:
 
 ```js
-for entry of tree.entries() {
+for (entry of tree.entries()) {
   console.log(entry.depth, entry.name, entry.type);
 }
 
@@ -184,7 +184,7 @@ function applyOps(tree, ops, openEditors) {
   // Perform these steps synchronously:
   const baseVersion = tree.getVersion();
   const fixupOps = tree.applyOps(ops);
-  for editor of openEditors {
+  for (editor of openEditors) {
     applyChanges(editor, tree.changesSince(editor.bufferId, baseVersion));
   }
 

--- a/memo_js/README.md
+++ b/memo_js/README.md
@@ -37,7 +37,7 @@ a/b
 c
 ```
 
-Since the application may need to perform I/O in order to fetch the base entries, you are free to start using the work tree before they are fully populated. You can also populate the base entries in a streaming fashion by calling `appendBaseEntries` multiple times and ensuring that the entries passed to each call pick up from the last entry passed in the previous call. If
+Since the application may need to perform I/O in order to fetch the base entries, you are free to start using the work tree before they are fully populated. You can also populate the base entries in a streaming fashion by calling `appendBaseEntries` multiple times and ensuring that the entries passed to each call pick up from the last entry passed in the previous call.
 
 For now, Memo has no internal concept of commits. Application code will need to arrange for all replicas to build on top of the same commit state and see the exact same base entries. When a participant wishes to commit, you'll need to coordinate building up a new work tree on top of the new state. We plan to handle more commit-related logic directly within the library in the future.
 

--- a/memo_js/README.md
+++ b/memo_js/README.md
@@ -24,8 +24,8 @@ const replicaId = 1;
 const tree = new WorkTree(replicaId);
 tree.appendBaseEntries([
   { depth: 1, name: "a", type: "Directory" },
-  { depth: 2, name: "b", type: "File" },
-  { depth: 1, name: "c", type: "File" },
+  { depth: 2, name: "b", type: "Text" },
+  { depth: 1, name: "c", type: "Text" }
 ])
 ```
 

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -24,7 +24,7 @@ export type Operation = string;
 
 export enum FileType {
   Directory = "Directory",
-  File = "File"
+  Text = "Text"
 }
 
 export enum FileStatus {

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -35,19 +35,19 @@ export enum FileStatus {
   Unchanged = "Unchanged"
 }
 
-  depth: number;
-  name: string;
-  type: FileType;
 export interface BaseEntry {
+  readonly depth: number;
+  readonly name: string;
+  readonly type: FileType;
 }
 
-  depth: number;
-  fileId: FileId;
-  type: FileType;
-  name: string;
-  status: FileStatus;
-  visible: boolean;
 export interface Entry {
+  readonly depth: number;
+  readonly fileId: FileId;
+  readonly type: FileType;
+  readonly name: string;
+  readonly status: FileStatus;
+  readonly visible: boolean;
 }
 
 export class WorkTree {

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -17,17 +17,17 @@ function request(req: any) {
   }
 }
 
-type FileId = string;
-type BufferId = string;
-type Version = object;
-type Operation = string;
+export type FileId = string;
+export type BufferId = string;
+export type Version = object;
+export type Operation = string;
 
-enum FileType {
+export enum FileType {
   Directory = "Directory",
   File = "File"
 }
 
-enum FileStatus {
+export enum FileStatus {
   New = "New",
   Renamed = "Renamed",
   Removed = "Removed",
@@ -35,22 +35,22 @@ enum FileStatus {
   Unchanged = "Unchanged"
 }
 
-interface BaseEntry {
   depth: number;
   name: string;
   type: FileType;
+export interface BaseEntry {
 }
 
-interface Entry {
   depth: number;
   fileId: FileId;
   type: FileType;
   name: string;
   status: FileStatus;
   visible: boolean;
+export interface Entry {
 }
 
-class WorkTree {
+export class WorkTree {
   private static rootFileId: FileId;
   private id: number;
 


### PR DESCRIPTION
A few more changes to the TS wrapper:

1. Export all the types so consumers can use them.
1. All the exposed fields are conceptually `readonly`. (I _think_! Correct me if I'm wrong!)
1. The file types are actually `Directory | Text` not `Directory | File`, judging by: https://github.com/atom/xray/blob/a7ec528e6c93814d7e1343c72832f58d620cf98c/memo_core/src/work_tree.rs#L127-L130