### PR TITLE
Even more types!

### DIFF
--- a/memo_js/README.md
+++ b/memo_js/README.md
@@ -93,7 +93,7 @@ const { fileId, operation } = tree.newTextFile();
 This returns a `fileId` and an `operation`, both of which are base64 encoded strings. The `operation` should be transmitted to all other collaborators and applied via `applyOps`, discussed in more detail later. After calling `newTextFile`, the created file exists in an "unsaved" form. To give it a name, pass the returned file id to the `rename` method.
 
 ```js
-const operation = tree.rename(fileId, tree.getRootFileId(), "foo.txt");
+const operation = tree.rename(fileId, WorkTree.getRootFileId(), "foo.txt");
 // Send the operation to peers...
 ```
 

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -17,10 +17,10 @@ function request(req: any) {
   }
 }
 
-export type FileId = string;
-export type BufferId = string;
-export type Version = object;
-export type Operation = string;
+export type FileId = string & { __kind: "FileId" };
+export type BufferId = string & { __kind: "BufferId" };
+export type Version = object & { __kind: "Version" };
+export type Operation = string & { __kind: "Operation" };
 
 export enum FileType {
   Directory = "Directory",

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -17,10 +17,12 @@ function request(req: any) {
   }
 }
 
-export type FileId = string & { __kind: "FileId" };
-export type BufferId = string & { __kind: "BufferId" };
-export type Version = object & { __kind: "Version" };
-export type Operation = string & { __kind: "Operation" };
+type Tagged<BaseType, TagName> = BaseType & { __tag: TagName };
+
+export type FileId = Tagged<string, "FileId">;
+export type BufferId = Tagged<string, "BufferId">;
+export type Version = Tagged<object, "Version">;
+export type Operation = Tagged<string, "Operation">;
 
 export enum FileType {
   Directory = "Directory",

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -167,7 +167,7 @@ export class WorkTree {
 
   entries(options?: {
     showDeleted?: boolean;
-    descendInto?: [FileId];
+    descendInto?: ReadonlyArray<FileId>;
   }): ReadonlyArray<Entry> {
     let showDeleted, descendInto;
     if (options) {


### PR DESCRIPTION
1. Fix an example in the README
1. Make another array readonly
1. Give our type aliases more specific type-level semantics.

(3) is nice because it gives type-level semantics to what would otherwise be plain type aliases. For example, even though `FileId` is represented as a `string`, it can't be just any `string`. It should only be a `string` that Memo vends. This lets us encode that in the type system:

```typescript
workTree.remove("my-made-up-id")
                ^^^ type error

const fileId = workTree.fileIdForPath("my-file.txt")
workTree.remove(fileId)
                ^^^ just fine
```

but it also gets erased at compile time so it doesn't change runtime semantics.