### PR TITLE
Support replay of operations with the same replica id

### DIFF
--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -533,7 +533,7 @@ impl Buffer {
         lamport_clock: &mut time::Lamport,
     ) -> Result<(), Error> {
         if id.seq <= self.version.get(id.replica_id) {
-            return Err(Error::InvalidOperation);
+            return Ok(());
         }
 
         let mut new_text = new_text.as_ref().cloned();
@@ -2616,8 +2616,10 @@ mod tests {
                                     })
                                     .unwrap_or(0);
 
-                                let insertion_index = rng.gen_range(min_index, queue.len() + 1);
-                                queue.insert(insertion_index, op.clone());
+                                for _ in 0..rng.gen_range(1, 4) {
+                                    let insertion_index = rng.gen_range(min_index, queue.len() + 1);
+                                    queue.insert(insertion_index, op.clone());
+                                }
                             }
                         }
                     }

--- a/memo_core/src/operation_queue.rs
+++ b/memo_core/src/operation_queue.rs
@@ -18,10 +18,14 @@ impl<T: Operation> OperationQueue<T> {
         OperationQueue(Tree::new())
     }
 
-    pub fn insert<I>(&mut self, ops: I)
-    where
-        I: IntoIterator<Item = T>,
-    {
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn insert(&mut self, mut ops: Vec<T>) {
+        ops.sort_by_key(|op| op.timestamp());
+        ops.dedup_by_key(|op| op.timestamp());
         let mut edits = ops
             .into_iter()
             .map(|op| Edit::Insert(op))

--- a/memo_core/src/time.rs
+++ b/memo_core/src/time.rs
@@ -36,6 +36,12 @@ impl Local {
         self.seq += 1;
         timestamp
     }
+
+    pub fn observe(&mut self, timestamp: Self) {
+        if timestamp.replica_id == self.replica_id {
+            self.seq = cmp::max(self.seq, timestamp.seq + 1);
+        }
+    }
 }
 
 impl Default for Local {
@@ -163,8 +169,6 @@ impl Lamport {
     }
 
     pub fn observe(&mut self, timestamp: Self) {
-        if timestamp.replica_id != self.replica_id {
-            self.value = cmp::max(self.value, timestamp.value) + 1;
-        }
+        self.value = cmp::max(self.value, timestamp.value) + 1;
     }
 }


### PR DESCRIPTION
After reloading a web page or performing a similar refresh in other situations, we may need to populate a `WorkTree` from a set of operations that includes operations produced by the same user that is performing the refresh. Previously, we had only tested applying operations produced by other replicas, and this wasn't working.

This PR also makes some adjustments to gracefully handle applying the same operations multiple times to paper over race conditions when subscribing to new operations and fetching existing operations.

This PR adds coverage for both of these scenarios to our randomized tests.

/cc @probablycorey 