### PR TITLE
Report also the full path when retrieving entries

### DIFF
--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -48,6 +48,7 @@ export interface Entry {
   readonly fileId: FileId;
   readonly type: FileType;
   readonly name: string;
+  readonly path: string;
   readonly status: FileStatus;
   readonly visible: boolean;
 }

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -173,6 +173,7 @@ struct Entry {
     file_type: FileType,
     depth: usize,
     name: String,
+    path: String,
     status: FileStatus,
     visible: bool,
 }
@@ -311,7 +312,8 @@ impl Server {
                         buffer_id,
                         ranges.into_iter().map(|range| range.start..range.end),
                         new_text.as_str(),
-                    ).map_err(|e| e.to_string())?;
+                    )
+                    .map_err(|e| e.to_string())?;
                 Ok(Response::Edit {
                     operation: Base64(op),
                 })
@@ -329,7 +331,8 @@ impl Server {
                         start: change.range.start,
                         end: change.range.end,
                         text: String::from_utf16_lossy(&change.code_units),
-                    }).collect();
+                    })
+                    .collect();
                 Ok(Response::ChangesSince { changes })
             }
             Request::GetText {
@@ -378,6 +381,7 @@ impl Server {
                                 file_type: entry.file_type,
                                 depth: entry.depth,
                                 name: entry.name.to_string_lossy().into_owned(),
+                                path: cursor.path().unwrap().to_string_lossy().into_owned(),
                                 status: entry.status,
                                 visible: entry.visible,
                             });

--- a/memo_js/test/tests.js
+++ b/memo_js/test/tests.js
@@ -70,6 +70,7 @@ suite("WorkTree", () => {
         fileId: tree1.fileIdForPath("a"),
         type: "Directory",
         name: "a",
+        path: "a",
         status: "Unchanged",
         visible: true
       }
@@ -85,6 +86,7 @@ suite("WorkTree", () => {
           fileId: tree1.fileIdForPath("a"),
           type: "Directory",
           name: "a",
+          path: "a",
           status: "Unchanged",
           visible: true
         },
@@ -93,6 +95,7 @@ suite("WorkTree", () => {
           fileId: tree1.fileIdForPath("a/b"),
           type: "Directory",
           name: "b",
+          path: "a/b",
           status: "Unchanged",
           visible: true
         },
@@ -101,6 +104,7 @@ suite("WorkTree", () => {
           fileId: c,
           type: "Text",
           name: "c",
+          path: "a/b/c",
           status: "Removed",
           visible: false
         },
@@ -109,6 +113,7 @@ suite("WorkTree", () => {
           fileId: dir1.fileId,
           type: "Directory",
           name: "x",
+          path: "a/b/x",
           status: "New",
           visible: true
         }


### PR DESCRIPTION
Fixes #146

This introduces an extra allocation for each reported entry in memo_js, but it removes an O(depth * log n) scan per entry while also making it more convenient to use for clients. We were already maintaining the path in the cursor, so this change was pretty straightforward.

/cc: @joshaber @nathansobo 