### PR TITLE
Report text files with edits as modified

### DIFF
--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -241,6 +241,10 @@ impl Buffer {
         }
     }
 
+    pub fn is_modified(&self) -> bool {
+        self.version > time::Global::new()
+    }
+
     pub fn len(&self) -> usize {
         self.fragments.extent::<usize>()
     }

--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -2557,6 +2557,17 @@ mod tests {
     }
 
     #[test]
+    fn test_is_modified() {
+        let mut buffer = Buffer::new("abc");
+        let mut local_clock = time::Local::new(1);
+        let mut lamport_clock = time::Lamport::new(1);
+
+        assert!(!buffer.is_modified());
+        buffer.edit(vec![1..2], "", &mut local_clock, &mut lamport_clock);
+        assert!(buffer.is_modified());
+    }
+
+    #[test]
     fn test_random_concurrent_edits() {
         for seed in 0..100 {
             println!("{:?}", seed);

--- a/memo_js/README.md
+++ b/memo_js/README.md
@@ -73,7 +73,7 @@ Each returned entry has the following fields:
 * `name`: The entry's name.
 * `fileId`: An opaque, base64 encoded binary value that can be passed to other methods on `WorkTree` to interact with this file.
 * `type`: The type of this file (`"File"` or `"Directory"`)
-* `status`: How this path has changed since the base commit (`"New"`, `"Renamed"`, `"Removed"`, `"Modified"`, or `"Unchanged"`)
+* `status`: How this path has changed since the base commit (`"New"`, `"Renamed"`, `"Removed"`, `"Modified"`, `"RenamedAndModified"`, or `"Unchanged"`)
 * `visible`: Whether or not this file is currently visible (not deleted).
 
 The `entries` method accepts two options as fields in an optional object passed to the method.

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -34,6 +34,7 @@ export enum FileStatus {
   Renamed = "Renamed",
   Removed = "Removed",
   Modified = "Modified",
+  RenamedAndModified = "RenamedAndModified",
   Unchanged = "Unchanged"
 }
 


### PR DESCRIPTION
This is a naive implementation. Even if the operations cancel each other out, we will still report the buffers as modified.

🍐'd with @nathansobo 

/cc: @probablycorey 