### PR TITLE
Don't encode operations as Base64, but use `Uint8Array`s instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,15 +54,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bincode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,7 +443,6 @@ dependencies = [
 name = "memo_js"
 version = "0.1.0"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -712,11 +702,6 @@ dependencies = [
 [[package]]
 name = "rustc-demangle"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "safemem"
-version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1322,7 +1307,6 @@ dependencies = [
 "checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
 "checksum backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbe525f66f42d207968308ee86bc2dd60aa5fab535b22e616323a173d097d8e"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
-"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bda13183df33055cbb84b847becce220d392df502ebe7a4a78d7021771ed94d0"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
@@ -1397,7 +1381,6 @@ dependencies = [
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
 "checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
-"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8674d439c964889e2476f474a3bf198cc9e199e77499960893bac5de7e9218a4"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"

--- a/memo_js/Cargo.toml
+++ b/memo_js/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-base64 = "0.9"
 bincode = "1.0"
 futures = "0.1"
 hex = "0.3"

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -35,13 +35,13 @@ export async function init() {
 }
 
 export type Version = Tagged<string, "Version">;
-export type Operation = Tagged<string, "Operation">;
+export type Operation = Tagged<Uint8Array, "Operation">;
 export type ReplicaId = Tagged<string, "ReplicaId">;
-export type OperationEnvelope = {
-  epochTimestamp: number;
-  epochReplicaId: string;
-  operation: Operation;
-};
+export interface OperationEnvelope {
+  epochTimestamp(): number;
+  epochReplicaId(): ReplicaId;
+  operation(): Operation;
+}
 
 export enum FileStatus {
   New = "New",

--- a/memo_js/test/tests.ts
+++ b/memo_js/test/tests.ts
@@ -35,8 +35,8 @@ suite("WorkTree", () => {
 
     const ops1 = [];
     const ops2 = [];
-    ops1.push(tree1.createFile("e", memo.FileType.Text).operation);
-    ops2.push(tree2.createFile("f", memo.FileType.Text).operation);
+    ops1.push(tree1.createFile("e", memo.FileType.Text).operation());
+    ops2.push(tree2.createFile("f", memo.FileType.Text).operation());
 
     await assert.rejects(() => tree2.openTextFile("e"));
 
@@ -59,7 +59,7 @@ suite("WorkTree", () => {
           { start: point(0, 9), end: point(0, 10) }
         ],
         "-"
-      ).operation
+      ).operation()
     );
     assert.strictEqual(tree1BufferC.getText(), "oid0-base-text");
 
@@ -74,10 +74,10 @@ suite("WorkTree", () => {
     ]);
     ops1.length = 0;
 
-    ops1.push(tree1.createFile("x", memo.FileType.Directory).operation);
-    ops1.push(tree1.createFile("x/y", memo.FileType.Directory).operation);
-    ops1.push(tree1.rename("x", "a/b/x").operation);
-    ops1.push(tree1.remove("a/b/d").operation);
+    ops1.push(tree1.createFile("x", memo.FileType.Directory).operation());
+    ops1.push(tree1.createFile("x/y", memo.FileType.Directory).operation());
+    ops1.push(tree1.rename("x", "a/b/x").operation());
+    ops1.push(tree1.remove("a/b/d").operation());
     assert.deepStrictEqual(await collectOps(tree2.applyOps(ops1)), []);
     assert.deepStrictEqual(await collectOps(tree1.applyOps(ops2)), []);
     ops1.length = 0;
@@ -205,7 +205,7 @@ async function collectOps(
   ops: AsyncIterable<memo.OperationEnvelope>
 ): Promise<memo.Operation[]> {
   const envelopes = await collect(ops);
-  return envelopes.map(({ operation }) => operation);
+  return envelopes.map(envelope => envelope.operation());
 }
 
 function point(row: number, column: number): memo.Point {


### PR DESCRIPTION
This pull request skips the extra base64 conversion when returning operations to the JS layer. The returned operations are now returned as `Uint8Array` instances.

/cc: @nathansobo 