### PR TITLE
Introduce more APIs to work with buffers and paths

### DIFF
--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -13,6 +13,7 @@ import {
   Change,
   ChangeObserver,
   ChangeObserverCallback,
+  CompositeDisposable,
   GitProvider,
   GitProviderWrapper,
   FileType,
@@ -130,11 +131,17 @@ export class Buffer {
   private id: BufferId;
   private tree: any;
   private observer: ChangeObserver;
+  private disposables: CompositeDisposable;
 
   constructor(id: BufferId, tree: any, observer: ChangeObserver) {
     this.id = id;
     this.tree = tree;
     this.observer = observer;
+    this.disposables = new CompositeDisposable();
+  }
+
+  dispose() {
+    this.disposables.dispose();
   }
 
   edit(oldRanges: Range[], newText: string): OperationEnvelope {
@@ -146,6 +153,6 @@ export class Buffer {
   }
 
   onChange(callback: ChangeObserverCallback) {
-    this.observer.onChange(this.id, callback);
+    this.disposables.add(this.observer.onChange(this.id, callback));
   }
 }

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -148,6 +148,10 @@ export class Buffer {
     return this.tree.edit(this.id, oldRanges, newText);
   }
 
+  getPath(): string | null {
+    return this.tree.path(this.id);
+  }
+
   getText(): string {
     return this.tree.text(this.id);
   }

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -106,6 +106,10 @@ export class WorkTree {
     return this.tree.remove(path);
   }
 
+  exists(path: Path): boolean {
+    return this.tree.exists(path);
+  }
+
   entries(options?: { descendInto?: Path[]; showDeleted?: boolean }): Entry[] {
     let descendInto = null;
     let showDeleted = false;

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -209,6 +209,13 @@ impl WorkTree {
         )
     }
 
+    pub fn path(&self, buffer_id: JsValue) -> Result<Option<String>, JsValue> {
+        Ok(self
+            .0
+            .path(buffer_id.into_serde().map_js_err()?)
+            .map(|path| path.to_string_lossy().into_owned()))
+    }
+
     pub fn text(&self, buffer_id: JsValue) -> Result<JsValue, JsValue> {
         self.0
             .text(buffer_id.into_serde().map_js_err()?)

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -196,6 +196,10 @@ impl WorkTree {
             .map_js_err()
     }
 
+    pub fn exists(&self, path: String) -> bool {
+        self.0.exists(&path)
+    }
+
     pub fn open_text_file(&mut self, path: String) -> js_sys::Promise {
         future_to_promise(
             self.0

--- a/memo_js/test/tests.ts
+++ b/memo_js/test/tests.ts
@@ -46,8 +46,10 @@ suite("WorkTree", () => {
     assert.strictEqual(ops2.length, 0);
 
     const tree1BufferC = await tree1.openTextFile("a/b/c");
-    const tree2BufferC = await tree2.openTextFile("a/b/c");
+    assert.strictEqual(tree1BufferC.getPath(), "a/b/c");
     assert.strictEqual(tree1BufferC.getText(), "oid0 base text");
+    const tree2BufferC = await tree2.openTextFile("a/b/c");
+    assert.strictEqual(tree2BufferC.getPath(), "a/b/c");
     assert.strictEqual(tree2BufferC.getText(), "oid0 base text");
 
     const tree1BufferChanges: memo.Change[] = [];
@@ -190,6 +192,9 @@ suite("WorkTree", () => {
       { start: point(0, 3), end: point(0, 5), text: "1 " },
       { start: point(0, 9), end: point(0, 10), text: " " }
     ]);
+
+    tree1.remove("a/b/c");
+    assert(tree1BufferC.getPath() == null);
   });
 
   test("incomplete base oids", async () => {

--- a/memo_js/test/tests.ts
+++ b/memo_js/test/tests.ts
@@ -173,6 +173,8 @@ suite("WorkTree", () => {
         }
       ]
     );
+    assert(tree1.exists("a/b/x"));
+    assert(!tree1.exists("a/b/d"));
 
     tree1BufferChanges.length = 0;
     tree2BufferChanges.length = 0;


### PR DESCRIPTION
This pull request introduces the following methods:

* `WorkTree.prototype.exists(path)`. This works exactly as its Node counterpart and returns a boolean indicating whether or not a file currently exists at the specified `path`. (cc5ec38)
* `Buffer.prototype.dispose()`. This method is currently just used to un-register the callbacks supplied to `onChange`. In the future, we could actually dispose the buffer and release memory from the WASM layer. (495fe82)
* `Buffer.prototype.getPath()`. If the underlying file that corresponds to the buffer is visible, this method will return a string representing its path. Otherwise, `null` will be returned, and that's an indicator that the file has been deleted. (34a2fca)

/cc: @probablycorey @nathansobo 