### PR TITLE
Wrap work tree operations in an envelope that contains the head of the current epoch

### DIFF
--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -2152,9 +2152,9 @@ impl Operation {
     pub fn to_flatbuf<'fbb>(
         &self,
         builder: &mut FlatBufferBuilder<'fbb>,
-    ) -> WIPOffset<serialization::buffer::OperationEnvelope<'fbb>> {
-        let operation_type;
-        let operation;
+    ) -> WIPOffset<serialization::buffer::Operation<'fbb>> {
+        let variant_type;
+        let variant;
         match self {
             Operation::Edit {
                 start_id,
@@ -2170,8 +2170,8 @@ impl Operation {
                     builder.create_string(String::from_utf16_lossy(&new_text.code_units).as_str())
                 });
                 let version_in_range = Some(version_in_range.to_flatbuf(builder));
-                operation_type = serialization::buffer::Operation::Edit;
-                operation = serialization::buffer::Edit::create(
+                variant_type = serialization::buffer::OperationVariant::Edit;
+                variant = serialization::buffer::Edit::create(
                     builder,
                     &serialization::buffer::EditArgs {
                         start_id: Some(&start_id.to_flatbuf()),
@@ -2188,22 +2188,22 @@ impl Operation {
             }
         }
 
-        serialization::buffer::OperationEnvelope::create(
+        serialization::buffer::Operation::create(
             builder,
-            &serialization::buffer::OperationEnvelopeArgs {
-                operation_type,
-                operation: Some(operation),
+            &serialization::buffer::OperationArgs {
+                variant_type,
+                variant: Some(variant),
             },
         )
     }
 
     pub fn from_flatbuf<'fbb>(
-        message: &serialization::buffer::OperationEnvelope<'fbb>,
+        message: &serialization::buffer::Operation<'fbb>,
     ) -> Result<Option<Self>, crate::Error> {
-        match message.operation_type() {
-            serialization::buffer::Operation::Edit => {
+        match message.variant_type() {
+            serialization::buffer::OperationVariant::Edit => {
                 let message = serialization::buffer::Edit::init_from_table(
-                    message.operation().ok_or(crate::Error::DeserializeError)?,
+                    message.variant().ok_or(crate::Error::DeserializeError)?,
                 );
                 Ok(Some(Operation::Edit {
                     start_id: time::Local::from_flatbuf(
@@ -2232,7 +2232,7 @@ impl Operation {
                     ),
                 }))
             }
-            serialization::buffer::Operation::NONE => Ok(None),
+            serialization::buffer::OperationVariant::NONE => Ok(None),
         }
     }
 }

--- a/memo_core/src/lib.rs
+++ b/memo_core/src/lib.rs
@@ -9,7 +9,9 @@ mod work_tree;
 
 pub use crate::buffer::{Buffer, Change, Point};
 pub use crate::epoch::{Cursor, DirEntry, Epoch, FileStatus, FileType, ROOT_FILE_ID};
-pub use crate::work_tree::{BufferId, ChangeObserver, GitProvider, Operation, WorkTree};
+pub use crate::work_tree::{
+    BufferId, ChangeObserver, GitProvider, Operation, OperationEnvelope, WorkTree,
+};
 use std::borrow::Cow;
 use std::fmt;
 use std::io;

--- a/memo_core/src/serialization/schema.fbs
+++ b/memo_core/src/serialization/schema.fbs
@@ -25,10 +25,10 @@ table Edit {
   lamport_timestamp:Timestamp;
 }
 
-union Operation { Edit }
+union OperationVariant { Edit }
 
-table OperationEnvelope {
-  operation: Operation;
+table Operation {
+  variant: OperationVariant;
 }
 
 namespace epoch;
@@ -64,7 +64,7 @@ table UpdateParent {
 
 table BufferOperation {
   file_id:FileId;
-  operations:[buffer.OperationEnvelope];
+  operations:[buffer.Operation];
   local_timestamp:Timestamp;
   lamport_timestamp:Timestamp;
 }
@@ -83,10 +83,10 @@ table EpochOperation {
   operation:epoch.Operation;
 }
 
-union Operation { StartEpoch, EpochOperation }
+union OperationVariant { StartEpoch, EpochOperation }
 
-table OperationEnvelope {
-   operation:Operation;
+table Operation {
+   variant:OperationVariant;
 }
 
-root_type OperationEnvelope;
+root_type Operation;

--- a/memo_core/src/serialization/schema_generated.rs
+++ b/memo_core/src/serialization/schema_generated.rs
@@ -216,16 +216,16 @@ pub mod buffer {
 #[allow(non_camel_case_types)]
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Debug)]
-pub enum Operation {
+pub enum OperationVariant {
   NONE = 0,
   Edit = 1,
 
 }
 
-const ENUM_MIN_OPERATION: u8 = 0;
-const ENUM_MAX_OPERATION: u8 = 1;
+const ENUM_MIN_OPERATION_VARIANT: u8 = 0;
+const ENUM_MAX_OPERATION_VARIANT: u8 = 1;
 
-impl<'a> flatbuffers::Follow<'a> for Operation {
+impl<'a> flatbuffers::Follow<'a> for OperationVariant {
   type Inner = Self;
   #[inline]
   fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
@@ -233,47 +233,47 @@ impl<'a> flatbuffers::Follow<'a> for Operation {
   }
 }
 
-impl flatbuffers::EndianScalar for Operation {
+impl flatbuffers::EndianScalar for OperationVariant {
   #[inline]
   fn to_little_endian(self) -> Self {
     let n = u8::to_le(self as u8);
-    let p = &n as *const u8 as *const Operation;
+    let p = &n as *const u8 as *const OperationVariant;
     unsafe { *p }
   }
   #[inline]
   fn from_little_endian(self) -> Self {
     let n = u8::from_le(self as u8);
-    let p = &n as *const u8 as *const Operation;
+    let p = &n as *const u8 as *const OperationVariant;
     unsafe { *p }
   }
 }
 
-impl flatbuffers::Push for Operation {
-    type Output = Operation;
+impl flatbuffers::Push for OperationVariant {
+    type Output = OperationVariant;
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-        flatbuffers::emplace_scalar::<Operation>(dst, *self);
+        flatbuffers::emplace_scalar::<OperationVariant>(dst, *self);
     }
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_OPERATION:[Operation; 2] = [
-  Operation::NONE,
-  Operation::Edit
+const ENUM_VALUES_OPERATION_VARIANT:[OperationVariant; 2] = [
+  OperationVariant::NONE,
+  OperationVariant::Edit
 ];
 
 #[allow(non_camel_case_types)]
-const ENUM_NAMES_OPERATION:[&'static str; 2] = [
+const ENUM_NAMES_OPERATION_VARIANT:[&'static str; 2] = [
     "NONE",
     "Edit"
 ];
 
-pub fn enum_name_operation(e: Operation) -> &'static str {
+pub fn enum_name_operation_variant(e: OperationVariant) -> &'static str {
   let index: usize = e as usize;
-  ENUM_NAMES_OPERATION[index]
+  ENUM_NAMES_OPERATION_VARIANT[index]
 }
 
-pub struct OperationUnionTableOffset {}
+pub struct OperationVariantUnionTableOffset {}
 pub enum EditOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
@@ -434,15 +434,15 @@ impl<'a: 'b, 'b> EditBuilder<'a, 'b> {
   }
 }
 
-pub enum OperationEnvelopeOffset {}
+pub enum OperationOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
-pub struct OperationEnvelope<'a> {
+pub struct Operation<'a> {
   pub _tab: flatbuffers::Table<'a>,
 }
 
-impl<'a> flatbuffers::Follow<'a> for OperationEnvelope<'a> {
-    type Inner = OperationEnvelope<'a>;
+impl<'a> flatbuffers::Follow<'a> for Operation<'a> {
+    type Inner = Operation<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
@@ -451,40 +451,39 @@ impl<'a> flatbuffers::Follow<'a> for OperationEnvelope<'a> {
     }
 }
 
-impl<'a> OperationEnvelope<'a> {
+impl<'a> Operation<'a> {
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        OperationEnvelope {
+        Operation {
             _tab: table,
         }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args OperationEnvelopeArgs) -> flatbuffers::WIPOffset<OperationEnvelope<'bldr>> {
-            
-      let mut builder = OperationEnvelopeBuilder::new(_fbb);
-      if let Some(x) = args.operation { builder.add_operation(x); }
-      builder.add_operation_type(args.operation_type);
+        args: &'args OperationArgs) -> flatbuffers::WIPOffset<Operation<'bldr>> {
+      let mut builder = OperationBuilder::new(_fbb);
+      if let Some(x) = args.variant { builder.add_variant(x); }
+      builder.add_variant_type(args.variant_type);
       builder.finish()
     }
 
-    pub const VT_OPERATION_TYPE: flatbuffers::VOffsetT = 4;
-    pub const VT_OPERATION: flatbuffers::VOffsetT = 6;
+    pub const VT_VARIANT_TYPE: flatbuffers::VOffsetT = 4;
+    pub const VT_VARIANT: flatbuffers::VOffsetT = 6;
 
   #[inline]
-  pub fn operation_type(&self) -> Operation {
-    self._tab.get::<Operation>(OperationEnvelope::VT_OPERATION_TYPE, Some(Operation::NONE)).unwrap()
+  pub fn variant_type(&self) -> OperationVariant {
+    self._tab.get::<OperationVariant>(Operation::VT_VARIANT_TYPE, Some(OperationVariant::NONE)).unwrap()
   }
   #[inline]
-  pub fn operation(&self) -> Option<flatbuffers::Table<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(OperationEnvelope::VT_OPERATION, None)
+  pub fn variant(&self) -> Option<flatbuffers::Table<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(Operation::VT_VARIANT, None)
   }
   #[inline]
   #[allow(non_snake_case)]
-  pub fn operation_as_edit(&'a self) -> Option<Edit> {
-    if self.operation_type() == Operation::Edit {
-      self.operation().map(|u| Edit::init_from_table(u))
+  pub fn variant_as_edit(&'a self) -> Option<Edit> {
+    if self.variant_type() == OperationVariant::Edit {
+      self.variant().map(|u| Edit::init_from_table(u))
     } else {
       None
     }
@@ -492,42 +491,42 @@ impl<'a> OperationEnvelope<'a> {
 
 }
 
-pub struct OperationEnvelopeArgs {
-    pub operation_type: Operation,
-    pub operation: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
+pub struct OperationArgs {
+    pub variant_type: OperationVariant,
+    pub variant: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
 }
-impl<'a> Default for OperationEnvelopeArgs {
+impl<'a> Default for OperationArgs {
     #[inline]
     fn default() -> Self {
-        OperationEnvelopeArgs {
-            operation_type: Operation::NONE,
-            operation: None,
+        OperationArgs {
+            variant_type: OperationVariant::NONE,
+            variant: None,
         }
     }
 }
-pub struct OperationEnvelopeBuilder<'a: 'b, 'b> {
+pub struct OperationBuilder<'a: 'b, 'b> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> OperationEnvelopeBuilder<'a, 'b> {
+impl<'a: 'b, 'b> OperationBuilder<'a, 'b> {
   #[inline]
-  pub fn add_operation_type(&mut self, operation_type: Operation) {
-    self.fbb_.push_slot::<Operation>(OperationEnvelope::VT_OPERATION_TYPE, operation_type, Operation::NONE);
+  pub fn add_variant_type(&mut self, variant_type: OperationVariant) {
+    self.fbb_.push_slot::<OperationVariant>(Operation::VT_VARIANT_TYPE, variant_type, OperationVariant::NONE);
   }
   #[inline]
-  pub fn add_operation(&mut self, operation: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(OperationEnvelope::VT_OPERATION, operation);
+  pub fn add_variant(&mut self, variant: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Operation::VT_VARIANT, variant);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> OperationEnvelopeBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> OperationBuilder<'a, 'b> {
     let start = _fbb.start_table();
-    OperationEnvelopeBuilder {
+    OperationBuilder {
       fbb_: _fbb,
       start_: start,
     }
   }
   #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<OperationEnvelope<'a>> {
+  pub fn finish(self) -> flatbuffers::WIPOffset<Operation<'a>> {
     let o = self.fbb_.end_table(self.start_);
     flatbuffers::WIPOffset::new(o.value())
   }
@@ -1328,8 +1327,8 @@ impl<'a> BufferOperation<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(BufferOperation::VT_FILE_ID, None)
   }
   #[inline]
-  pub fn operations(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<super::buffer::OperationEnvelope<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<super::buffer::OperationEnvelope<'a>>>>>(BufferOperation::VT_OPERATIONS, None)
+  pub fn operations(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<super::buffer::Operation<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<super::buffer::Operation<'a>>>>>(BufferOperation::VT_OPERATIONS, None)
   }
   #[inline]
   pub fn local_timestamp(&self) -> Option<&'a super::Timestamp> {
@@ -1364,7 +1363,7 @@ impl<'a> BufferOperation<'a> {
 pub struct BufferOperationArgs<'a> {
     pub file_id_type: FileId,
     pub file_id: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
-    pub operations: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<super::buffer::OperationEnvelope<'a >>>>>,
+    pub operations: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<super::buffer::Operation<'a >>>>>,
     pub local_timestamp: Option<&'a  super::Timestamp>,
     pub lamport_timestamp: Option<&'a  super::Timestamp>,
 }
@@ -1394,7 +1393,7 @@ impl<'a: 'b, 'b> BufferOperationBuilder<'a, 'b> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(BufferOperation::VT_FILE_ID, file_id);
   }
   #[inline]
-  pub fn add_operations(&mut self, operations: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<super::buffer::OperationEnvelope<'b >>>>) {
+  pub fn add_operations(&mut self, operations: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<super::buffer::Operation<'b >>>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(BufferOperation::VT_OPERATIONS, operations);
   }
   #[inline]
@@ -1435,17 +1434,17 @@ pub mod worktree {
 #[allow(non_camel_case_types)]
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Debug)]
-pub enum Operation {
+pub enum OperationVariant {
   NONE = 0,
   StartEpoch = 1,
   EpochOperation = 2,
 
 }
 
-const ENUM_MIN_OPERATION: u8 = 0;
-const ENUM_MAX_OPERATION: u8 = 2;
+const ENUM_MIN_OPERATION_VARIANT: u8 = 0;
+const ENUM_MAX_OPERATION_VARIANT: u8 = 2;
 
-impl<'a> flatbuffers::Follow<'a> for Operation {
+impl<'a> flatbuffers::Follow<'a> for OperationVariant {
   type Inner = Self;
   #[inline]
   fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
@@ -1453,49 +1452,49 @@ impl<'a> flatbuffers::Follow<'a> for Operation {
   }
 }
 
-impl flatbuffers::EndianScalar for Operation {
+impl flatbuffers::EndianScalar for OperationVariant {
   #[inline]
   fn to_little_endian(self) -> Self {
     let n = u8::to_le(self as u8);
-    let p = &n as *const u8 as *const Operation;
+    let p = &n as *const u8 as *const OperationVariant;
     unsafe { *p }
   }
   #[inline]
   fn from_little_endian(self) -> Self {
     let n = u8::from_le(self as u8);
-    let p = &n as *const u8 as *const Operation;
+    let p = &n as *const u8 as *const OperationVariant;
     unsafe { *p }
   }
 }
 
-impl flatbuffers::Push for Operation {
-    type Output = Operation;
+impl flatbuffers::Push for OperationVariant {
+    type Output = OperationVariant;
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-        flatbuffers::emplace_scalar::<Operation>(dst, *self);
+        flatbuffers::emplace_scalar::<OperationVariant>(dst, *self);
     }
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_OPERATION:[Operation; 3] = [
-  Operation::NONE,
-  Operation::StartEpoch,
-  Operation::EpochOperation
+const ENUM_VALUES_OPERATION_VARIANT:[OperationVariant; 3] = [
+  OperationVariant::NONE,
+  OperationVariant::StartEpoch,
+  OperationVariant::EpochOperation
 ];
 
 #[allow(non_camel_case_types)]
-const ENUM_NAMES_OPERATION:[&'static str; 3] = [
+const ENUM_NAMES_OPERATION_VARIANT:[&'static str; 3] = [
     "NONE",
     "StartEpoch",
     "EpochOperation"
 ];
 
-pub fn enum_name_operation(e: Operation) -> &'static str {
+pub fn enum_name_operation_variant(e: OperationVariant) -> &'static str {
   let index: usize = e as usize;
-  ENUM_NAMES_OPERATION[index]
+  ENUM_NAMES_OPERATION_VARIANT[index]
 }
 
-pub struct OperationUnionTableOffset {}
+pub struct OperationVariantUnionTableOffset {}
 pub enum StartEpochOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
@@ -1714,15 +1713,15 @@ impl<'a: 'b, 'b> EpochOperationBuilder<'a, 'b> {
   }
 }
 
-pub enum OperationEnvelopeOffset {}
+pub enum OperationOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
-pub struct OperationEnvelope<'a> {
+pub struct Operation<'a> {
   pub _tab: flatbuffers::Table<'a>,
 }
 
-impl<'a> flatbuffers::Follow<'a> for OperationEnvelope<'a> {
-    type Inner = OperationEnvelope<'a>;
+impl<'a> flatbuffers::Follow<'a> for Operation<'a> {
+    type Inner = Operation<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
@@ -1731,39 +1730,39 @@ impl<'a> flatbuffers::Follow<'a> for OperationEnvelope<'a> {
     }
 }
 
-impl<'a> OperationEnvelope<'a> {
+impl<'a> Operation<'a> {
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        OperationEnvelope {
+        Operation {
             _tab: table,
         }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args OperationEnvelopeArgs) -> flatbuffers::WIPOffset<OperationEnvelope<'bldr>> {
-      let mut builder = OperationEnvelopeBuilder::new(_fbb);
-      if let Some(x) = args.operation { builder.add_operation(x); }
-      builder.add_operation_type(args.operation_type);
+        args: &'args OperationArgs) -> flatbuffers::WIPOffset<Operation<'bldr>> {
+      let mut builder = OperationBuilder::new(_fbb);
+      if let Some(x) = args.variant { builder.add_variant(x); }
+      builder.add_variant_type(args.variant_type);
       builder.finish()
     }
 
-    pub const VT_OPERATION_TYPE: flatbuffers::VOffsetT = 4;
-    pub const VT_OPERATION: flatbuffers::VOffsetT = 6;
+    pub const VT_VARIANT_TYPE: flatbuffers::VOffsetT = 4;
+    pub const VT_VARIANT: flatbuffers::VOffsetT = 6;
 
   #[inline]
-  pub fn operation_type(&self) -> Operation {
-    self._tab.get::<Operation>(OperationEnvelope::VT_OPERATION_TYPE, Some(Operation::NONE)).unwrap()
+  pub fn variant_type(&self) -> OperationVariant {
+    self._tab.get::<OperationVariant>(Operation::VT_VARIANT_TYPE, Some(OperationVariant::NONE)).unwrap()
   }
   #[inline]
-  pub fn operation(&self) -> Option<flatbuffers::Table<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(OperationEnvelope::VT_OPERATION, None)
+  pub fn variant(&self) -> Option<flatbuffers::Table<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(Operation::VT_VARIANT, None)
   }
   #[inline]
   #[allow(non_snake_case)]
-  pub fn operation_as_start_epoch(&'a self) -> Option<StartEpoch> {
-    if self.operation_type() == Operation::StartEpoch {
-      self.operation().map(|u| StartEpoch::init_from_table(u))
+  pub fn variant_as_start_epoch(&'a self) -> Option<StartEpoch> {
+    if self.variant_type() == OperationVariant::StartEpoch {
+      self.variant().map(|u| StartEpoch::init_from_table(u))
     } else {
       None
     }
@@ -1771,9 +1770,9 @@ impl<'a> OperationEnvelope<'a> {
 
   #[inline]
   #[allow(non_snake_case)]
-  pub fn operation_as_epoch_operation(&'a self) -> Option<EpochOperation> {
-    if self.operation_type() == Operation::EpochOperation {
-      self.operation().map(|u| EpochOperation::init_from_table(u))
+  pub fn variant_as_epoch_operation(&'a self) -> Option<EpochOperation> {
+    if self.variant_type() == OperationVariant::EpochOperation {
+      self.variant().map(|u| EpochOperation::init_from_table(u))
     } else {
       None
     }
@@ -1781,66 +1780,66 @@ impl<'a> OperationEnvelope<'a> {
 
 }
 
-pub struct OperationEnvelopeArgs {
-    pub operation_type: Operation,
-    pub operation: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
+pub struct OperationArgs {
+    pub variant_type: OperationVariant,
+    pub variant: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
 }
-impl<'a> Default for OperationEnvelopeArgs {
+impl<'a> Default for OperationArgs {
     #[inline]
     fn default() -> Self {
-        OperationEnvelopeArgs {
-            operation_type: Operation::NONE,
-            operation: None,
+        OperationArgs {
+            variant_type: OperationVariant::NONE,
+            variant: None,
         }
     }
 }
-pub struct OperationEnvelopeBuilder<'a: 'b, 'b> {
+pub struct OperationBuilder<'a: 'b, 'b> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b> OperationEnvelopeBuilder<'a, 'b> {
+impl<'a: 'b, 'b> OperationBuilder<'a, 'b> {
   #[inline]
-  pub fn add_operation_type(&mut self, operation_type: Operation) {
-    self.fbb_.push_slot::<Operation>(OperationEnvelope::VT_OPERATION_TYPE, operation_type, Operation::NONE);
+  pub fn add_variant_type(&mut self, variant_type: OperationVariant) {
+    self.fbb_.push_slot::<OperationVariant>(Operation::VT_VARIANT_TYPE, variant_type, OperationVariant::NONE);
   }
   #[inline]
-  pub fn add_operation(&mut self, operation: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(OperationEnvelope::VT_OPERATION, operation);
+  pub fn add_variant(&mut self, variant: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Operation::VT_VARIANT, variant);
   }
   #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> OperationEnvelopeBuilder<'a, 'b> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> OperationBuilder<'a, 'b> {
     let start = _fbb.start_table();
-    OperationEnvelopeBuilder {
+    OperationBuilder {
       fbb_: _fbb,
       start_: start,
     }
   }
   #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<OperationEnvelope<'a>> {
+  pub fn finish(self) -> flatbuffers::WIPOffset<Operation<'a>> {
     let o = self.fbb_.end_table(self.start_);
     flatbuffers::WIPOffset::new(o.value())
   }
 }
 
 #[inline]
-pub fn get_root_as_operation_envelope<'a>(buf: &'a [u8]) -> OperationEnvelope<'a> {
-  flatbuffers::get_root::<OperationEnvelope<'a>>(buf)
+pub fn get_root_as_operation<'a>(buf: &'a [u8]) -> Operation<'a> {
+  flatbuffers::get_root::<Operation<'a>>(buf)
 }
 
 #[inline]
-pub fn get_size_prefixed_root_as_operation_envelope<'a>(buf: &'a [u8]) -> OperationEnvelope<'a> {
-  flatbuffers::get_size_prefixed_root::<OperationEnvelope<'a>>(buf)
+pub fn get_size_prefixed_root_as_operation<'a>(buf: &'a [u8]) -> Operation<'a> {
+  flatbuffers::get_size_prefixed_root::<Operation<'a>>(buf)
 }
 
 #[inline]
-pub fn finish_operation_envelope_buffer<'a, 'b>(
+pub fn finish_operation_buffer<'a, 'b>(
     fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    root: flatbuffers::WIPOffset<OperationEnvelope<'a>>) {
+    root: flatbuffers::WIPOffset<Operation<'a>>) {
   fbb.finish(root, None);
 }
 
 #[inline]
-pub fn finish_size_prefixed_operation_envelope_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<OperationEnvelope<'a>>) {
+pub fn finish_size_prefixed_operation_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Operation<'a>>) {
   fbb.finish_size_prefixed(root, None);
 }
 }  // pub mod worktree

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -33,6 +33,11 @@ pub struct WorkTree {
     observer: Option<Rc<ChangeObserver>>,
 }
 
+pub struct OperationEnvelope {
+    pub epoch_head: Option<Oid>,
+    pub operation: Operation,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Operation {
     StartEpoch {
@@ -77,7 +82,13 @@ impl WorkTree {
         ops: I,
         git: Rc<GitProvider>,
         observer: Option<Rc<ChangeObserver>>,
-    ) -> Result<(WorkTree, Box<Stream<Item = Operation, Error = Error>>), Error>
+    ) -> Result<
+        (
+            WorkTree,
+            Box<Stream<Item = OperationEnvelope, Error = Error>>,
+        ),
+        Error,
+    >
     where
         I: 'static + IntoIterator<Item = Operation>,
     {
@@ -93,24 +104,30 @@ impl WorkTree {
         };
 
         let ops = if ops.peek().is_none() {
-            Box::new(tree.reset(base)) as Box<Stream<Item = Operation, Error = Error>>
+            Box::new(tree.reset(base)) as Box<Stream<Item = OperationEnvelope, Error = Error>>
         } else {
-            Box::new(tree.apply_ops(ops)?) as Box<Stream<Item = Operation, Error = Error>>
+            Box::new(tree.apply_ops(ops)?) as Box<Stream<Item = OperationEnvelope, Error = Error>>
         };
 
         Ok((tree, ops))
     }
 
-    pub fn reset(&mut self, head: Option<Oid>) -> impl Stream<Item = Operation, Error = Error> {
+    pub fn reset(
+        &mut self,
+        head: Option<Oid>,
+    ) -> impl Stream<Item = OperationEnvelope, Error = Error> {
         let epoch_id = self.lamport_clock.borrow_mut().tick();
-        stream::once(Ok(Operation::StartEpoch { epoch_id, head }))
-            .chain(self.start_epoch(epoch_id, head))
+        stream::once(Ok(OperationEnvelope {
+            epoch_head: head,
+            operation: Operation::StartEpoch { epoch_id, head },
+        }))
+        .chain(self.start_epoch(epoch_id, head))
     }
 
     pub fn apply_ops<I>(
         &mut self,
         ops: I,
-    ) -> Result<impl Stream<Item = Operation, Error = Error>, Error>
+    ) -> Result<impl Stream<Item = OperationEnvelope, Error = Error>, Error>
     where
         I: IntoIterator<Item = Operation>,
     {
@@ -163,9 +180,11 @@ impl WorkTree {
                 }
             }
 
-            let fixup_ops_stream = Box::new(stream::iter_ok(Operation::stamp(epoch.id, fixup_ops)));
+            let fixup_ops_stream = Box::new(stream::iter_ok(OperationEnvelope::wrap_many(
+                epoch.id, epoch.head, fixup_ops,
+            )));
             Ok(epoch_streams.into_iter().fold(
-                fixup_ops_stream as Box<Stream<Item = Operation, Error = Error>>,
+                fixup_ops_stream as Box<Stream<Item = OperationEnvelope, Error = Error>>,
                 |acc, stream| Box::new(acc.chain(stream)),
             ))
         } else {
@@ -177,7 +196,7 @@ impl WorkTree {
         &mut self,
         new_epoch_id: epoch::Id,
         new_head: Option<Oid>,
-    ) -> Box<Stream<Item = Operation, Error = Error>> {
+    ) -> Box<Stream<Item = OperationEnvelope, Error = Error>> {
         if self
             .epoch
             .as_ref()
@@ -202,10 +221,14 @@ impl WorkTree {
                                 base_entries,
                                 &mut lamport_clock.borrow_mut(),
                             )?;
-                            Ok(stream::iter_ok(Operation::stamp(new_epoch_id, fixup_ops)))
+                            Ok(stream::iter_ok(OperationEnvelope::wrap_many(
+                                new_epoch_id,
+                                Some(new_head),
+                                fixup_ops,
+                            )))
                         })
                         .flatten(),
-                ) as Box<Stream<Item = Operation, Error = Error>>
+                ) as Box<Stream<Item = OperationEnvelope, Error = Error>>
             } else {
                 Box::new(stream::empty())
             };
@@ -245,7 +268,7 @@ impl WorkTree {
         }
     }
 
-    pub fn create_file<P>(&self, path: P, file_type: FileType) -> Result<Operation, Error>
+    pub fn create_file<P>(&self, path: P, file_type: FileType) -> Result<OperationEnvelope, Error>
     where
         P: AsRef<Path>,
     {
@@ -259,20 +282,21 @@ impl WorkTree {
         } else {
             epoch::ROOT_FILE_ID
         };
-        let epoch_id = cur_epoch.id;
         let operation = cur_epoch.create_file(
             parent_id,
             name,
             file_type,
             &mut self.lamport_clock.borrow_mut(),
         )?;
-        Ok(Operation::EpochOperation {
-            epoch_id,
+
+        Ok(OperationEnvelope::wrap(
+            cur_epoch.id,
+            cur_epoch.head,
             operation,
-        })
+        ))
     }
 
-    pub fn rename<P1, P2>(&self, old_path: P1, new_path: P2) -> Result<Operation, Error>
+    pub fn rename<P1, P2>(&self, old_path: P1, new_path: P2) -> Result<OperationEnvelope, Error>
     where
         P1: AsRef<Path>,
         P2: AsRef<Path>,
@@ -291,32 +315,33 @@ impl WorkTree {
             epoch::ROOT_FILE_ID
         };
 
-        let epoch_id = cur_epoch.id;
         let operation = cur_epoch.rename(
             file_id,
             new_parent_id,
             new_name,
             &mut self.lamport_clock.borrow_mut(),
         )?;
-        Ok(Operation::EpochOperation {
-            epoch_id,
+
+        Ok(OperationEnvelope::wrap(
+            cur_epoch.id,
+            cur_epoch.head,
             operation,
-        })
+        ))
     }
 
-    pub fn remove<P>(&self, path: P) -> Result<Operation, Error>
+    pub fn remove<P>(&self, path: P) -> Result<OperationEnvelope, Error>
     where
         P: AsRef<Path>,
     {
         let mut cur_epoch = self.cur_epoch_mut();
         let file_id = cur_epoch.file_id(path.as_ref())?;
-        let epoch_id = cur_epoch.id;
         let operation = cur_epoch.remove(file_id, &mut self.lamport_clock.borrow_mut())?;
 
-        Ok(Operation::EpochOperation {
-            epoch_id,
+        Ok(OperationEnvelope::wrap(
+            cur_epoch.id,
+            cur_epoch.head,
             operation,
-        })
+        ))
     }
 
     pub fn open_text_file<P>(&self, path: P) -> Box<Future<Item = BufferId, Error = Error>>
@@ -423,14 +448,13 @@ impl WorkTree {
         buffer_id: BufferId,
         old_ranges: I,
         new_text: T,
-    ) -> Result<Operation, Error>
+    ) -> Result<OperationEnvelope, Error>
     where
         I: IntoIterator<Item = Range<usize>>,
         T: Into<Text>,
     {
         let file_id = self.buffer_file_id(buffer_id)?;
         let mut cur_epoch = self.cur_epoch_mut();
-        let epoch_id = cur_epoch.id;
         let operation = cur_epoch
             .edit(
                 file_id,
@@ -440,10 +464,11 @@ impl WorkTree {
             )
             .unwrap();
 
-        Ok(Operation::EpochOperation {
-            epoch_id,
+        Ok(OperationEnvelope::wrap(
+            cur_epoch.id,
+            cur_epoch.head,
             operation,
-        })
+        ))
     }
 
     pub fn edit_2d<I, T>(
@@ -451,14 +476,13 @@ impl WorkTree {
         buffer_id: BufferId,
         old_ranges: I,
         new_text: T,
-    ) -> Result<Operation, Error>
+    ) -> Result<OperationEnvelope, Error>
     where
         I: IntoIterator<Item = Range<Point>>,
         T: Into<Text>,
     {
         let file_id = self.buffer_file_id(buffer_id)?;
         let mut cur_epoch = self.cur_epoch_mut();
-        let epoch_id = cur_epoch.id;
         let operation = cur_epoch
             .edit_2d(
                 file_id,
@@ -468,10 +492,11 @@ impl WorkTree {
             )
             .unwrap();
 
-        Ok(Operation::EpochOperation {
-            epoch_id,
+        Ok(OperationEnvelope::wrap(
+            cur_epoch.id,
+            cur_epoch.head,
             operation,
-        })
+        ))
     }
 
     pub fn path(&self, buffer_id: BufferId) -> Option<PathBuf> {
@@ -521,6 +546,34 @@ impl WorkTree {
             .get(&buffer_id)
             .cloned()
             .ok_or(Error::InvalidBufferId)
+    }
+}
+
+impl OperationEnvelope {
+    fn wrap(epoch_id: epoch::Id, epoch_head: Option<Oid>, operation: epoch::Operation) -> Self {
+        OperationEnvelope {
+            epoch_head,
+            operation: Operation::EpochOperation {
+                epoch_id,
+                operation,
+            },
+        }
+    }
+
+    fn wrap_many<T>(epoch_id: epoch::Id, epoch_head: Option<Oid>, operations: T) -> Vec<Self>
+    where
+        T: IntoIterator<Item = epoch::Operation>,
+    {
+        operations
+            .into_iter()
+            .map(move |operation| OperationEnvelope {
+                epoch_head,
+                operation: Operation::EpochOperation {
+                    epoch_id,
+                    operation,
+                },
+            })
+            .collect()
     }
 }
 
@@ -676,7 +729,7 @@ impl SwitchEpoch {
 }
 
 impl Future for SwitchEpoch {
-    type Item = Vec<Operation>;
+    type Item = Vec<OperationEnvelope>;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -754,10 +807,11 @@ impl Future for SwitchEpoch {
                         // can't, we will resort to path-based mapping or to creating a completely
                         // new file id for untitled buffers.
                         let (new_file_id, operation) = to_assign.new_text_file(&mut lamport_clock);
-                        fixup_ops.push(Operation::EpochOperation {
-                            epoch_id: to_assign.id,
+                        fixup_ops.push(OperationEnvelope::wrap(
+                            to_assign.id,
+                            to_assign.head,
                             operation,
-                        });
+                        ));
                         to_assign.open_text_file(new_file_id, "", &mut lamport_clock)?;
                         let operation = to_assign.edit(
                             new_file_id,
@@ -765,17 +819,19 @@ impl Future for SwitchEpoch {
                             cur_epoch.text(buffers[&buffer_id])?.into_string().as_str(),
                             &mut lamport_clock,
                         )?;
-                        fixup_ops.push(Operation::EpochOperation {
-                            epoch_id: to_assign.id,
+                        fixup_ops.push(OperationEnvelope::wrap(
+                            to_assign.id,
+                            to_assign.head,
                             operation,
-                        });
+                        ));
                         buffer_mappings.push((buffer_id, new_file_id));
                     }
                 }
 
                 if let Some(ops) = deferred_ops.remove(&to_assign.id) {
-                    fixup_ops.extend(Operation::stamp(
+                    fixup_ops.extend(OperationEnvelope::wrap_many(
                         to_assign.id,
+                        to_assign.head,
                         to_assign.apply_ops(ops, &mut lamport_clock)?,
                     ));
                 }
@@ -887,7 +943,7 @@ mod tests {
                 network.add_peer(tree.replica_id());
                 network.broadcast(
                     tree.replica_id(),
-                    serialize_ops(ops.collect().wait().unwrap()),
+                    serialize_ops(open_envelopes(ops.collect().wait().unwrap())),
                     &mut rng,
                 );
                 trees.push(tree);
@@ -905,16 +961,13 @@ mod tests {
                     network.broadcast(replica_id, serialize_ops(ops), &mut rng);
                 } else if k == 1 {
                     let head = *rng.choose(&commits).unwrap();
-                    let ops = tree.reset(head).collect().wait().unwrap();
+                    let ops = open_envelopes(tree.reset(head).collect().wait().unwrap());
                     network.broadcast(replica_id, serialize_ops(ops), &mut rng);
                 } else if k == 2 {
                     let received_ops = network.receive(replica_id, &mut rng);
                     let fixup_ops = tree.apply_ops(deserialize_ops(received_ops)).unwrap();
-                    network.broadcast(
-                        replica_id,
-                        serialize_ops(fixup_ops.collect().wait().unwrap()),
-                        &mut rng,
-                    );
+                    let fixup_ops = open_envelopes(fixup_ops.collect().wait().unwrap());
+                    network.broadcast(replica_id, serialize_ops(fixup_ops), &mut rng);
                 } else if k == 3 {
                     let buffer_id = if tree.open_buffers().is_empty() || rng.gen() {
                         tree.select_path(FileType::Text, &mut rng).map(|path| {
@@ -931,7 +984,10 @@ mod tests {
                         let start = rng.gen_range(0, end + 1);
                         let text = gen_text(&mut rng);
                         observer.edit(buffer_id, start..end, text.as_str());
-                        let op = tree.edit(buffer_id, Some(start..end), text).unwrap();
+                        let op = tree
+                            .edit(buffer_id, Some(start..end), text)
+                            .unwrap()
+                            .operation;
                         network.broadcast(replica_id, serialize_ops(Some(op)), &mut rng);
                     }
                 }
@@ -945,7 +1001,7 @@ mod tests {
                     let fixup_ops = tree.apply_ops(deserialize_ops(received_ops)).unwrap();
                     network.broadcast(
                         replica_id,
-                        serialize_ops(fixup_ops.collect().wait().unwrap()),
+                        serialize_ops(open_envelopes(fixup_ops.collect().wait().unwrap())),
                         &mut rng,
                     );
                 }
@@ -1002,7 +1058,7 @@ mod tests {
         let (mut tree_2, ops_2) = WorkTree::new(
             Uuid::from_u128(2),
             Some(commit_0),
-            ops_1.collect().wait().unwrap(),
+            open_envelopes(ops_1.collect().wait().unwrap()),
             git.clone(),
             Some(observer_2.clone()),
         )
@@ -1019,12 +1075,12 @@ mod tests {
         assert_eq!(tree_1.text_str(a_1), git.tree(commit_0).text_str(a_base));
         assert_eq!(tree_2.text_str(a_2), git.tree(commit_0).text_str(a_base));
 
-        let ops_1 = tree_1.reset(Some(commit_1)).collect().wait().unwrap();
+        let ops_1 = open_envelopes(tree_1.reset(Some(commit_1)).collect().wait().unwrap());
         assert_eq!(tree_1.dir_entries(), git.tree(commit_1).dir_entries());
         assert_eq!(tree_1.text_str(a_1), git.tree(commit_1).text_str(a_1));
         assert_eq!(observer_1.text(a_1), tree_1.text_str(a_1));
 
-        let ops_2 = tree_2.reset(Some(commit_2)).collect().wait().unwrap();
+        let ops_2 = open_envelopes(tree_2.reset(Some(commit_2)).collect().wait().unwrap());
         assert_eq!(tree_2.dir_entries(), git.tree(commit_2).dir_entries());
         assert_eq!(tree_2.text_str(a_2), git.tree(commit_2).text_str(a_2));
         assert_eq!(observer_2.text(a_2), tree_2.text_str(a_2));
@@ -1079,7 +1135,7 @@ mod tests {
         let (tree_2, ops_2) = WorkTree::new(
             Uuid::from_u128(1),
             Some(commit_0),
-            ops_1.collect().wait().unwrap(),
+            open_envelopes(ops_1.collect().wait().unwrap()),
             git.clone(),
             None,
         )
@@ -1093,7 +1149,7 @@ mod tests {
         let edit_op = tree_2.edit(buffer_id_2, Some(0..0), "x").unwrap();
         tree_1
             .borrow_mut()
-            .apply_ops(Some(edit_op))
+            .apply_ops(Some(edit_op.operation))
             .unwrap()
             .collect()
             .wait()
@@ -1106,6 +1162,10 @@ mod tests {
             .collect()
             .wait()
             .unwrap();
+    }
+
+    fn open_envelopes<I: IntoIterator<Item = OperationEnvelope>>(envelopes: I) -> Vec<Operation> {
+        envelopes.into_iter().map(|e| e.operation).collect()
     }
 
     fn serialize_ops<I: IntoIterator<Item = Operation>>(ops: I) -> Vec<Vec<u8>> {

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -40,6 +40,7 @@ export type ReplicaId = Tagged<string, "ReplicaId">;
 export interface OperationEnvelope {
   epochTimestamp(): number;
   epochReplicaId(): ReplicaId;
+  epochHead(): null | Oid;
   operation(): Operation;
 }
 

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -46,7 +46,7 @@ pub struct WorkTreeNewResult {
 }
 
 #[wasm_bindgen]
-pub struct OperationEnvelope(memo::Operation);
+pub struct OperationEnvelope(memo::OperationEnvelope);
 
 #[derive(Copy, Clone, Serialize, Deserialize)]
 struct EditRange {
@@ -275,22 +275,27 @@ impl WorkTreeNewResult {
 
 #[wasm_bindgen]
 impl OperationEnvelope {
-    fn new(operation: memo::Operation) -> Self {
+    fn new(operation: memo::OperationEnvelope) -> Self {
         OperationEnvelope(operation)
     }
 
     #[wasm_bindgen(js_name = epochReplicaId)]
     pub fn epoch_replica_id(&self) -> JsValue {
-        JsValue::from_serde(&self.0.epoch_id().replica_id).unwrap()
+        JsValue::from_serde(&self.0.operation.epoch_id().replica_id).unwrap()
     }
 
     #[wasm_bindgen(js_name = epochTimestamp)]
     pub fn epoch_timestamp(&self) -> JsValue {
-        JsValue::from_serde(&self.0.epoch_id().value).unwrap()
+        JsValue::from_serde(&self.0.operation.epoch_id().value).unwrap()
+    }
+
+    #[wasm_bindgen(js_name = epochHead)]
+    pub fn epoch_head(&self) -> JsValue {
+        JsValue::from_serde(&self.0.epoch_head.map(|head| HexOid(head))).unwrap()
     }
 
     pub fn operation(&self) -> Vec<u8> {
-        self.0.serialize()
+        self.0.operation.serialize()
     }
 }
 

--- a/memo_js/test/tests.ts
+++ b/memo_js/test/tests.ts
@@ -190,10 +190,25 @@ suite("WorkTree", () => {
     ]);
   });
 
-  test("incomplete base oids", async () => {
+  test("an invalid base commit oid throws an error instead of crashing", async () => {
     assert.throws(() => {
       WorkTree.create("12345678", [], new TestGitProvider());
     }, /12345678/);
+  });
+
+  test("the epoch head is available on operation envelopes", async () => {
+    const OID = "0".repeat(40);
+
+    const git = new TestGitProvider();
+    git.commit(OID, [{ depth: 1, name: "a", type: memo.FileType.Directory }]);
+
+    const [tree1] = WorkTree.create(null, [], git);
+    const envelope1 = tree1.createFile("x", memo.FileType.Text);
+    assert.strictEqual(envelope1.epochHead(), null);
+    const [envelope2] = await collect(tree1.reset(OID));
+    assert.strictEqual(envelope2.epochHead(), OID);
+    const envelope3 = tree1.createFile("y", memo.FileType.Text);
+    assert.strictEqual(envelope3.epochHead(), OID);
   });
 });
 

--- a/memo_js/test/tests.ts
+++ b/memo_js/test/tests.ts
@@ -192,7 +192,7 @@ suite("WorkTree", () => {
 
   test("incomplete base oids", async () => {
     assert.throws(() => {
-      const [tree, fixupOps] = WorkTree.create("12345678", [], new TestGitProvider());
+      WorkTree.create("12345678", [], new TestGitProvider());
     }, /12345678/);
   });
 });

--- a/memo_js/test/tsconfig.json
+++ b/memo_js/test/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "include": ["src/**/*.ts"],
   "compilerOptions": {
     "outDir": "./dist/",
     "noImplicitAny": true,
@@ -8,6 +7,6 @@
     "declarationMap": true,
     "declaration": true,
     "lib": ["es2015", "esnext"],
-    "types": ["node"]
+    "types": ["mocha", "node"]
   }
 }


### PR DESCRIPTION
Operations are grouped into *epochs*. Each epoch begins at a specific *base commit*. When persisting operations to a database, we want to associate epochs with their base commit so we can determine the *active epoch* for a given branch.

When we receive an operation with an unknown epoch id, we want to create that epoch lazily on the server. Usually, the first operation for a new epoch that we'll receive is the `EpochStart` operation, which includes the head commit's OID. However, we want it to be possible for the server to treat operations as opaque binary, and we don't necessarily want to enforce a strict order on how operations for a given epoch are processed and stored by the server. For these reasons, we're deciding to send the epoch head OID to the server with each operation. This will make it possible to create a new epoch and associate it with the correct start commit regardless of the order in which we process operations for storage.

This will unfortunately add an extra 20 bytes of overhead per operation that we send to the server, which most of the time will be redundant. If we think we can guarantee that the `EpochStart` operation will always be processed first, we can revisit this. For now it seems easier to relax that constraint.

/cc @probablycorey @as-cii 