### PR TITLE
Add Buffer.prototype.getDeferredOperationCount

### DIFF
--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -310,6 +310,10 @@ impl Buffer {
         ChangesIter { cursor, since }
     }
 
+    pub fn deferred_ops_len(&self) -> usize {
+        self.deferred_ops.len()
+    }
+
     pub fn edit<I, T>(
         &mut self,
         old_ranges: I,

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -725,7 +725,7 @@ impl Epoch {
                 _ => {
                     return Err(Error::InvalidPath(
                         format!("path {:?} contains unrecognized components", path).into(),
-                    ))
+                    ));
                 }
             }
         }
@@ -791,6 +791,14 @@ impl Epoch {
     ) -> Result<impl Iterator<Item = buffer::Change>, Error> {
         if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
             Ok(buffer.changes_since(version))
+        } else {
+            Err(Error::InvalidFileId("file has not been opened".into()))
+        }
+    }
+
+    pub fn buffer_deferred_ops_len(&self, file_id: FileId) -> Result<usize, Error> {
+        if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
+            Ok(buffer.deferred_ops_len())
         } else {
             Err(Error::InvalidFileId("file has not been opened".into()))
         }
@@ -2070,6 +2078,46 @@ mod tests {
         assert!(epoch_1
             .open_text_file(dir_id, Text::from(""), &mut lamport_clock_1)
             .is_err());
+    }
+
+    #[test]
+    fn test_buffer_deferred_ops_len() -> Result<(), Error> {
+        let replica_1_id = Uuid::from_u128(1);
+        let mut epoch_1 = Epoch::with_replica_id(replica_1_id);
+        let mut clock_1 = time::Lamport::new(replica_1_id);
+
+        let (file_id, new_file_op) = epoch_1.new_text_file(&mut clock_1);
+        epoch_1.open_text_file(file_id, "", &mut clock_1).unwrap();
+        let edit_1_op = epoch_1.edit(file_id, Some(0..0), "135", &mut clock_1)?;
+        let edit_2_op = epoch_1.edit(file_id, Some(1..1), "2", &mut clock_1)?;
+        let edit_3_op = epoch_1.edit(file_id, Some(3..3), "4", &mut clock_1)?;
+
+        let replica_2_id = Uuid::from_u128(2);
+        let mut epoch_2 = Epoch::with_replica_id(replica_2_id);
+        let mut clock_2 = time::Lamport::new(replica_2_id);
+        epoch_2.apply_ops(Some(new_file_op.clone()), &mut clock_2)?;
+
+        epoch_2.open_text_file(file_id, "", &mut clock_2)?;
+        assert_eq!(epoch_2.buffer_deferred_ops_len(file_id)?, 0);
+
+        epoch_2.apply_ops(Some(edit_3_op.clone()), &mut clock_2)?;
+        assert_eq!(epoch_2.buffer_deferred_ops_len(file_id)?, 1);
+
+        epoch_2.apply_ops(Some(edit_2_op.clone()), &mut clock_2)?;
+        assert_eq!(epoch_2.buffer_deferred_ops_len(file_id)?, 2);
+
+        epoch_2.apply_ops(Some(edit_1_op.clone()), &mut clock_2)?;
+        assert_eq!(epoch_2.buffer_deferred_ops_len(file_id)?, 0);
+
+        // If the buffer has never been opened, we can't determine how many operations are deferred.
+        let replica_3_id = Uuid::from_u128(3);
+        let mut epoch_3 = Epoch::with_replica_id(replica_3_id);
+        let mut clock_3 = time::Lamport::new(replica_3_id);
+        epoch_3.apply_ops(Some(new_file_op), &mut clock_3)?;
+        epoch_3.apply_ops(Some(edit_3_op), &mut clock_3)?;
+        assert!(epoch_3.buffer_deferred_ops_len(file_id).is_err());
+
+        Ok(())
     }
 
     #[test]

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -550,6 +550,11 @@ impl WorkTree {
         self.cur_epoch().changes_since(file_id, version)
     }
 
+    pub fn buffer_deferred_ops_len(&self, buffer_id: BufferId) -> Result<usize, Error> {
+        let file_id = self.buffer_file_id(buffer_id)?;
+        self.cur_epoch().buffer_deferred_ops_len(file_id)
+    }
+
     fn cur_epoch(&self) -> Ref<Epoch> {
         self.epoch.as_ref().unwrap().borrow()
     }

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -175,4 +175,8 @@ export class Buffer {
   onChange(callback: ChangeObserverCallback): Disposable {
     return this.observer.onChange(this.id, callback);
   }
+
+  getDeferredOperationCount(): number {
+    return this.tree.buffer_deferred_ops_len(this.id);
+  }
 }

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -242,6 +242,14 @@ impl WorkTree {
             .map_err(|e| e.into_js_err())
     }
 
+    pub fn buffer_deferred_ops_len(&self, buffer_id: JsValue) -> Result<u32, JsValue> {
+        let buffer_id = buffer_id.into_serde().map_err(|e| e.into_js_err())?;
+        self.0
+            .buffer_deferred_ops_len(buffer_id)
+            .map(|len| len as u32)
+            .map_err(|e| e.into_js_err())
+    }
+
     pub fn edit(
         &self,
         buffer_id: JsValue,

--- a/memo_js/test/tests.ts
+++ b/memo_js/test/tests.ts
@@ -60,9 +60,11 @@ suite("WorkTree", () => {
     const tree1BufferC = await tree1.openTextFile("a/b/c");
     assert.strictEqual(tree1BufferC.getPath(), "a/b/c");
     assert.strictEqual(tree1BufferC.getText(), "oid0 base text");
+    assert.strictEqual(tree1BufferC.getDeferredOperationCount(), 0);
     const tree2BufferC = await tree2.openTextFile("a/b/c");
     assert.strictEqual(tree2BufferC.getPath(), "a/b/c");
     assert.strictEqual(tree2BufferC.getText(), "oid0 base text");
+    assert.strictEqual(tree1BufferC.getDeferredOperationCount(), 0);
 
     const tree1BufferChanges: Change[] = [];
     tree1BufferC.onChange(c => tree1BufferChanges.push(...c));


### PR DESCRIPTION
This pull request introduces a new method on `Buffer` that allows to retrieve how many operations haven't been applied yet due to a deferral, in an effort to start adding observability into memo's internal state.

We have pretty good confidence that, so long as all messages are delivered, the system will converge. However, higher layers in the stack (e.g., networking, storage, etc.) may cause memo not to see every operation, and so this new simple function will help take operation delivery out of the equation (if the deferred count is zero).

/cc: @joshaber 