### PR TITLE
Introduce Selections

### DIFF
--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -292,7 +292,7 @@ impl Buffer {
     }
 
     pub fn selections_changed_since(&self, since: &time::Global) -> bool {
-        since.observed(self.selections_last_update)
+        !since.observed(self.selections_last_update)
     }
 
     pub fn changes_since(&self, since: &time::Global) -> impl Iterator<Item = Change> {
@@ -3061,14 +3061,14 @@ mod tests {
                 .filter(|set_id| local_clock.replica_id == set_id.replica_id)
                 .collect::<Vec<_>>();
             let set_id = rng.choose(&replica_selection_sets);
-            if set_id.is_some() && rng.gen() {
+            if set_id.is_some() && rng.gen_weighted_bool(6) {
                 let op = self
                     .remove_selection_set(*set_id.unwrap(), local_clock, lamport_clock)
                     .unwrap();
                 operations.push(op);
             } else {
                 let mut selections = Vec::new();
-                for _ in 0..rng.gen_range(1, 5) {
+                for _ in 0..5 {
                     let start = rng.gen_range(0, self.len() + 1);
                     let end = rng.gen_range(0, self.len() + 1);
                     let selection = if start > end {

--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -405,7 +405,7 @@ impl Buffer {
     {
         self.selections
             .remove(&set_id)
-            .ok_or(Error::InvalidSelectionSet)?;
+            .ok_or(Error::InvalidSelectionSet(set_id))?;
 
         let mut selections = self.selections_from_ranges(ranges)?;
         self.merge_selections(&mut selections);
@@ -429,7 +429,7 @@ impl Buffer {
     ) -> Result<Operation, Error> {
         self.selections
             .remove(&set_id)
-            .ok_or(Error::InvalidSelectionSet)?;
+            .ok_or(Error::InvalidSelectionSet(set_id))?;
 
         let local_timestamp = local_clock.tick();
         self.version.observe(local_timestamp);
@@ -448,7 +448,7 @@ impl Buffer {
         let selections = self
             .selections
             .get(&set_id)
-            .ok_or(Error::InvalidSelectionSet)?;
+            .ok_or(Error::InvalidSelectionSet(set_id))?;
         Ok(selections.iter().map(move |selection| {
             let start = self.point_for_anchor(&selection.start).unwrap();
             let end = self.point_for_anchor(&selection.end).unwrap();

--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -3056,6 +3056,10 @@ mod tests {
                     buffer.all_selections().collect::<HashMap<_, _>>(),
                     buffers[0].all_selections().collect::<HashMap<_, _>>()
                 );
+                assert_eq!(
+                    buffer.all_selection_ranges().collect::<HashMap<_, _>>(),
+                    buffers[0].all_selection_ranges().collect::<HashMap<_, _>>()
+                );
             }
         }
     }

--- a/memo_core/src/buffer.rs
+++ b/memo_core/src/buffer.rs
@@ -274,7 +274,6 @@ impl Buffer {
         self.iter().collect::<Vec<u16>>()
     }
 
-    #[cfg(test)]
     pub fn to_string(&self) -> String {
         String::from_utf16_lossy(&self.to_u16_chars())
     }

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -682,19 +682,22 @@ impl Epoch {
         )
     }
 
-    pub fn add_selection_set(
+    pub fn add_selection_set<I>(
         &mut self,
         file_id: FileId,
-        selections: Vec<Selection>,
+        ranges: I,
         lamport_clock: &mut time::Lamport,
-    ) -> Result<(SelectionSetId, Operation), Error> {
+    ) -> Result<(SelectionSetId, Operation), Error>
+    where
+        I: IntoIterator<Item = Range<Point>>,
+    {
         let mut new_set_id = None;
         let operation = self.mutate_buffer(
             file_id,
             lamport_clock,
             |buffer, local_clock, lamport_clock| {
                 let (set_id, operation) =
-                    buffer.add_selection_set(selections, local_clock, lamport_clock);
+                    buffer.add_selection_set(ranges, local_clock, lamport_clock)?;
                 new_set_id = Some(set_id);
                 Ok(vec![operation])
             },

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -2063,7 +2063,7 @@ mod tests {
         );
 
         let changes = epoch_2
-            .with_buffer(file_id, |b| Ok(b.changes_since(base_version.clone())))
+            .with_buffer(file_id, |b| Ok(b.changes_since(&base_version)))
             .unwrap()
             .collect::<Vec<_>>();
         assert_eq!(changes.len(), 2);

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -1,5 +1,5 @@
 use crate::btree::{self, SeekBias};
-use crate::buffer::{self, Buffer, Point, Text};
+use crate::buffer::{self, Buffer, Text};
 use crate::operation_queue::{self, OperationQueue};
 use crate::serialization;
 use crate::time;
@@ -13,7 +13,7 @@ use smallvec::SmallVec;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
-use std::ops::{Add, AddAssign, Range};
+use std::ops::{Add, AddAssign};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
@@ -188,14 +188,6 @@ impl Epoch {
             local_clock: time::Local::new(replica_id),
             text_files: HashMap::new(),
             deferred_ops: OperationQueue::new(),
-        }
-    }
-
-    pub fn buffer_version(&self, file_id: FileId) -> Option<time::Global> {
-        if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
-            Some(buffer.version.clone())
-        } else {
-            None
         }
     }
 
@@ -642,55 +634,26 @@ impl Epoch {
         Ok(operation)
     }
 
-    pub fn edit<I, T>(
-        &mut self,
-        file_id: FileId,
-        old_ranges: I,
-        new_text: T,
-        lamport_clock: &mut time::Lamport,
-    ) -> Result<Operation, Error>
+    pub fn with_buffer<F, T>(&self, file_id: FileId, f: F) -> Result<T, Error>
     where
-        I: IntoIterator<Item = Range<usize>>,
-        T: Into<Text>,
+        F: FnOnce(&Buffer) -> Result<T, Error>,
     {
-        self.mutate_buffer(
-            file_id,
-            lamport_clock,
-            |buffer, local_clock, lamport_clock| {
-                Ok(buffer.edit(old_ranges, new_text, local_clock, lamport_clock))
-            },
-        )
+        if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
+            f(buffer)
+        } else {
+            Err(Error::InvalidFileId("file has not been opened".into()))
+        }
     }
 
-    pub fn edit_2d<I, T>(
-        &mut self,
-        file_id: FileId,
-        old_ranges: I,
-        new_text: T,
-        lamport_clock: &mut time::Lamport,
-    ) -> Result<Operation, Error>
-    where
-        I: IntoIterator<Item = Range<Point>>,
-        T: Into<Text>,
-    {
-        self.mutate_buffer(
-            file_id,
-            lamport_clock,
-            |buffer, local_clock, lamport_clock| {
-                Ok(buffer.edit_2d(old_ranges, new_text, local_clock, lamport_clock))
-            },
-        )
-    }
-
-    fn mutate_buffer<F>(
+    pub fn with_buffer_mut<F, I>(
         &mut self,
         file_id: FileId,
         lamport_clock: &mut time::Lamport,
         mutate: F,
     ) -> Result<Operation, Error>
     where
-        F: FnOnce(&mut Buffer, &mut time::Local, &mut time::Lamport)
-            -> Result<Vec<buffer::Operation>, Error>,
+        F: FnOnce(&mut Buffer, &mut time::Local, &mut time::Lamport) -> Result<I, Error>,
+        I: IntoIterator<Item = buffer::Operation>,
     {
         if let Some(TextFile::Buffered(buffer)) = self.text_files.get_mut(&file_id) {
             let operations = mutate(buffer, &mut self.local_clock, lamport_clock)?;
@@ -698,7 +661,7 @@ impl Epoch {
             self.version.observe(local_timestamp);
             Ok(Operation::BufferOperation {
                 file_id,
-                operations,
+                operations: operations.into_iter().collect(),
                 local_timestamp,
                 lamport_timestamp: lamport_clock.tick(),
             })
@@ -784,26 +747,6 @@ impl Epoch {
             Some(path)
         } else {
             None
-        }
-    }
-
-    pub fn text(&self, file_id: FileId) -> Result<buffer::Iter, Error> {
-        if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
-            Ok(buffer.iter())
-        } else {
-            Err(Error::InvalidFileId("file has not been opened".into()))
-        }
-    }
-
-    pub fn changes_since(
-        &self,
-        file_id: FileId,
-        version: time::Global,
-    ) -> Result<impl Iterator<Item = buffer::Change>, Error> {
-        if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
-            Ok(buffer.changes_since(version))
-        } else {
-            Err(Error::InvalidFileId("file has not been opened".into()))
         }
     }
 
@@ -1894,13 +1837,29 @@ mod tests {
         epoch.rename(e, a, "z", &mut lamport_clock).unwrap();
 
         epoch.open_text_file(c, "123", &mut lamport_clock).unwrap();
-        epoch.edit(c, Some(0..0), "x", &mut lamport_clock).unwrap();
+        epoch
+            .with_buffer_mut(
+                c,
+                &mut lamport_clock,
+                |buffer, local_clock, lamport_clock| {
+                    Ok(buffer.edit(Some(0..0), "x", local_clock, lamport_clock))
+                },
+            )
+            .unwrap();
 
         epoch
             .rename(g, ROOT_FILE_ID, "g", &mut lamport_clock)
             .unwrap();
         epoch.open_text_file(g, "456", &mut lamport_clock).unwrap();
-        epoch.edit(g, Some(0..0), "y", &mut lamport_clock).unwrap();
+        epoch
+            .with_buffer_mut(
+                g,
+                &mut lamport_clock,
+                |buffer, local_clock, lamport_clock| {
+                    Ok(buffer.edit(Some(0..0), "y", local_clock, lamport_clock))
+                },
+            )
+            .unwrap();
 
         let mut cursor = epoch.cursor().unwrap();
         assert_eq!(
@@ -2056,27 +2015,55 @@ mod tests {
         epoch_2
             .open_text_file(file_id, base_text.clone(), &mut lamport_clock_2)
             .unwrap();
-        let ops = epoch_2.edit(file_id, vec![1..2, 3..3], "x", &mut lamport_clock_2);
-        epoch_1.apply_ops(ops, &mut lamport_clock_1).unwrap();
+        let op = epoch_2
+            .with_buffer_mut(
+                file_id,
+                &mut lamport_clock_2,
+                |buffer, local_clock, lamport_clock| {
+                    Ok(buffer.edit(vec![1..2, 3..3], "x", local_clock, lamport_clock))
+                },
+            )
+            .unwrap();
+        epoch_1.apply_ops(Some(op), &mut lamport_clock_1).unwrap();
 
         // Must call open_text_file on any given replica first before interacting with a buffer.
-        assert!(epoch_1.text(file_id).is_err());
+        assert!(epoch_1.with_buffer(file_id, |_| Ok(())).is_err());
         epoch_1
             .open_text_file(file_id, base_text, &mut lamport_clock_1)
             .unwrap();
-        assert_eq!(epoch_1.text(file_id).unwrap().into_string(), "axcx");
-        assert_eq!(epoch_2.text(file_id).unwrap().into_string(), "axcx");
+        assert_eq!(
+            epoch_1.with_buffer(file_id, |b| Ok(b.to_string())).unwrap(),
+            "axcx"
+        );
+        assert_eq!(
+            epoch_2.with_buffer(file_id, |b| Ok(b.to_string())).unwrap(),
+            "axcx"
+        );
 
-        let ops = epoch_1.edit(file_id, vec![1..2, 4..4], "y", &mut lamport_clock_1);
+        let op = epoch_1
+            .with_buffer_mut(
+                file_id,
+                &mut lamport_clock_1,
+                |buffer, local_clock, lamport_clock| {
+                    Ok(buffer.edit(vec![1..2, 4..4], "y", local_clock, lamport_clock))
+                },
+            )
+            .unwrap();
         let base_version = epoch_2.version();
 
-        epoch_2.apply_ops(ops, &mut lamport_clock_2).unwrap();
+        epoch_2.apply_ops(Some(op), &mut lamport_clock_2).unwrap();
 
-        assert_eq!(epoch_1.text(file_id).unwrap().into_string(), "aycxy");
-        assert_eq!(epoch_2.text(file_id).unwrap().into_string(), "aycxy");
+        assert_eq!(
+            epoch_1.with_buffer(file_id, |b| Ok(b.to_string())).unwrap(),
+            "aycxy"
+        );
+        assert_eq!(
+            epoch_2.with_buffer(file_id, |b| Ok(b.to_string())).unwrap(),
+            "aycxy"
+        );
 
         let changes = epoch_2
-            .changes_since(file_id, base_version.clone())
+            .with_buffer(file_id, |b| Ok(b.changes_since(base_version.clone())))
             .unwrap()
             .collect::<Vec<_>>();
         assert_eq!(changes.len(), 2);
@@ -2336,7 +2323,7 @@ mod tests {
                         .collect::<Vec<_>>();
                     let file_id = *rng.choose(&buffered_file_ids).unwrap();
                     let op = self
-                        .mutate_buffer(
+                        .with_buffer_mut(
                             file_id,
                             lamport_clock,
                             |buffer, local_clock, lamport_clock| {

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -702,6 +702,20 @@ impl Epoch {
         Ok((new_set_id.unwrap(), operation))
     }
 
+    pub fn selections(
+        &self,
+        file_id: FileId,
+    ) -> Result<Vec<(SelectionSetId, Vec<Selection>)>, Error> {
+        if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
+            Ok(buffer
+                .selections()
+                .map(|(set_id, selections)| (*set_id, selections.clone()))
+                .collect())
+        } else {
+            Err(Error::InvalidFileId("file has not been opened".into()))
+        }
+    }
+
     fn mutate_buffer<F>(
         &mut self,
         file_id: FileId,

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -742,13 +742,13 @@ impl Epoch {
         )
     }
 
-    pub fn selections(
+    pub fn all_selections(
         &self,
         file_id: FileId,
     ) -> Result<Vec<(SelectionSetId, Vec<Selection>)>, Error> {
         if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
             Ok(buffer
-                .selections()
+                .all_selections()
                 .map(|(set_id, selections)| (*set_id, selections.clone()))
                 .collect())
         } else {
@@ -759,9 +759,21 @@ impl Epoch {
     pub fn selection_ranges<'a>(
         &'a self,
         file_id: FileId,
+        set_id: SelectionSetId,
+    ) -> Result<impl Iterator<Item = Range<Point>> + 'a, Error> {
+        if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
+            buffer.selection_ranges(set_id)
+        } else {
+            Err(Error::InvalidFileId("file has not been opened".into()))
+        }
+    }
+
+    pub fn all_selection_ranges<'a>(
+        &'a self,
+        file_id: FileId,
     ) -> Result<impl Iterator<Item = (SelectionSetId, Vec<Range<Point>>)> + 'a, Error> {
         if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
-            Ok(buffer.selection_ranges())
+            Ok(buffer.all_selection_ranges())
         } else {
             Err(Error::InvalidFileId("file has not been opened".into()))
         }

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -1761,7 +1761,7 @@ impl btree::Dimension<ChildRefValueSummary> for usize {
 impl TextFile {
     fn is_modified(&self) -> bool {
         match self {
-            TextFile::Deferred(ops) => !ops.is_empty(),
+            TextFile::Deferred(ops) => ops.iter().any(|op| op.is_edit()),
             TextFile::Buffered(buffer) => buffer.is_modified(),
         }
     }

--- a/memo_core/src/lib.rs
+++ b/memo_core/src/lib.rs
@@ -28,6 +28,9 @@ pub enum Error {
     InvalidBufferId,
     InvalidDirEntry,
     InvalidOperation,
+    InvalidSelectionSet,
+    InvalidAnchor,
+    OffsetOutOfRange,
     CursorExhausted,
 }
 
@@ -82,6 +85,28 @@ impl From<io::Error> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, f)
+    }
+}
+
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Error::IoError(err_1), Error::IoError(err_2)) => {
+                err_1.kind() == err_2.kind() && err_1.to_string() == err_2.to_string()
+            }
+            (Error::DeserializeError, Error::DeserializeError) => true,
+            (Error::InvalidPath(err_1), Error::InvalidPath(err_2)) => err_1 == err_2,
+            (Error::InvalidOperations, Error::InvalidOperations) => true,
+            (Error::InvalidFileId(err_1), Error::InvalidFileId(err_2)) => err_1 == err_2,
+            (Error::InvalidBufferId, Error::InvalidBufferId) => true,
+            (Error::InvalidDirEntry, Error::InvalidDirEntry) => true,
+            (Error::InvalidOperation, Error::InvalidOperation) => true,
+            (Error::InvalidSelectionSet, Error::InvalidSelectionSet) => true,
+            (Error::InvalidAnchor, Error::InvalidAnchor) => true,
+            (Error::OffsetOutOfRange, Error::OffsetOutOfRange) => true,
+            (Error::CursorExhausted, Error::CursorExhausted) => true,
+            _ => false,
+        }
     }
 }
 

--- a/memo_core/src/lib.rs
+++ b/memo_core/src/lib.rs
@@ -10,7 +10,8 @@ mod work_tree;
 pub use crate::buffer::{Buffer, Change, Point};
 pub use crate::epoch::{Cursor, DirEntry, Epoch, FileStatus, FileType, ROOT_FILE_ID};
 pub use crate::work_tree::{
-    BufferId, ChangeObserver, GitProvider, Operation, OperationEnvelope, WorkTree,
+    BufferId, ChangeObserver, GitProvider, LocalSelectionSetId, Operation, OperationEnvelope,
+    WorkTree,
 };
 use std::borrow::Cow;
 use std::fmt;
@@ -30,7 +31,8 @@ pub enum Error {
     InvalidBufferId,
     InvalidDirEntry,
     InvalidOperation,
-    InvalidSelectionSet,
+    InvalidSelectionSet(buffer::SelectionSetId),
+    InvalidLocalSelectionSet(LocalSelectionSetId),
     InvalidAnchor,
     OffsetOutOfRange,
     CursorExhausted,
@@ -103,7 +105,10 @@ impl PartialEq for Error {
             (Error::InvalidBufferId, Error::InvalidBufferId) => true,
             (Error::InvalidDirEntry, Error::InvalidDirEntry) => true,
             (Error::InvalidOperation, Error::InvalidOperation) => true,
-            (Error::InvalidSelectionSet, Error::InvalidSelectionSet) => true,
+            (Error::InvalidSelectionSet(id_1), Error::InvalidSelectionSet(id_2)) => id_1 == id_2,
+            (Error::InvalidLocalSelectionSet(id_1), Error::InvalidLocalSelectionSet(id_2)) => {
+                id_1 == id_2
+            }
             (Error::InvalidAnchor, Error::InvalidAnchor) => true,
             (Error::OffsetOutOfRange, Error::OffsetOutOfRange) => true,
             (Error::CursorExhausted, Error::CursorExhausted) => true,

--- a/memo_core/src/lib.rs
+++ b/memo_core/src/lib.rs
@@ -16,7 +16,6 @@ use std::io;
 use uuid::Uuid;
 
 pub type ReplicaId = Uuid;
-pub type UserId = u64;
 pub type Oid = [u8; 20];
 
 #[derive(Debug)]

--- a/memo_core/src/lib.rs
+++ b/memo_core/src/lib.rs
@@ -10,8 +10,8 @@ mod work_tree;
 pub use crate::buffer::{Buffer, Change, Point};
 pub use crate::epoch::{Cursor, DirEntry, Epoch, FileStatus, FileType, ROOT_FILE_ID};
 pub use crate::work_tree::{
-    BufferId, ChangeObserver, GitProvider, LocalSelectionSetId, Operation, OperationEnvelope,
-    WorkTree,
+    BufferId, BufferSelectionRanges, ChangeObserver, GitProvider, LocalSelectionSetId, Operation,
+    OperationEnvelope, WorkTree,
 };
 use std::borrow::Cow;
 use std::fmt;

--- a/memo_core/src/operation_queue.rs
+++ b/memo_core/src/operation_queue.rs
@@ -1,7 +1,7 @@
 use crate::btree::{Cursor, Dimension, Edit, Item, KeyedItem, Tree};
+use crate::time;
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign};
-use crate::time;
 
 pub trait Operation: Clone + Debug + Eq {
     fn timestamp(&self) -> time::Lamport;

--- a/memo_core/src/operation_queue.rs
+++ b/memo_core/src/operation_queue.rs
@@ -1,7 +1,7 @@
 use crate::btree::{Cursor, Dimension, Edit, Item, KeyedItem, Tree};
-use crate::time;
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign};
+use crate::time;
 
 pub trait Operation: Clone + Debug + Eq {
     fn timestamp(&self) -> time::Lamport;

--- a/memo_core/src/serialization/schema.fbs
+++ b/memo_core/src/serialization/schema.fbs
@@ -45,7 +45,6 @@ table Edit {
 table UpdateSelections {
   set_id:Timestamp;
   selections:[Selection];
-  local_timestamp:Timestamp;
   lamport_timestamp:Timestamp;
 }
 

--- a/memo_core/src/serialization/schema.fbs
+++ b/memo_core/src/serialization/schema.fbs
@@ -14,6 +14,23 @@ table GlobalTimestamp {
 
 namespace buffer;
 
+enum AnchorVariant : byte { Start, End, Middle }
+
+enum AnchorBias : byte { Left, Right 
+
+table Anchor {
+  variant:AnchorVariant;
+  insertion_id:Timestamp;
+  offset:uint64;
+  bias:AnchorBias;
+}
+
+table Selection {
+  start:Anchor;
+  end:Anchor;
+  reversed:bool;
+}
+
 table Edit {
   start_id:Timestamp;
   start_offset:uint64;
@@ -25,7 +42,13 @@ table Edit {
   lamport_timestamp:Timestamp;
 }
 
-union Operation { Edit }
+table UpdateSelections {
+  set_id:Timestamp;
+  selections:[Selection];
+  lamport_timestamp:Timestamp;
+}
+
+union Operation { Edit, UpdateSelections }
 
 table OperationEnvelope {
   operation: Operation;

--- a/memo_core/src/serialization/schema.fbs
+++ b/memo_core/src/serialization/schema.fbs
@@ -14,9 +14,9 @@ table GlobalTimestamp {
 
 namespace buffer;
 
-enum AnchorVariant : byte { Start, End, Middle }
+enum AnchorVariant : byte { Start, Middle, End }
 
-enum AnchorBias : byte { Left, Right 
+enum AnchorBias : byte { Left, Right }
 
 table Anchor {
   variant:AnchorVariant;

--- a/memo_core/src/serialization/schema.fbs
+++ b/memo_core/src/serialization/schema.fbs
@@ -45,6 +45,7 @@ table Edit {
 table UpdateSelections {
   set_id:Timestamp;
   selections:[Selection];
+  local_timestamp:Timestamp;
   lamport_timestamp:Timestamp;
 }
 

--- a/memo_core/src/serialization/schema_generated.rs
+++ b/memo_core/src/serialization/schema_generated.rs
@@ -214,16 +214,140 @@ pub mod buffer {
   use self::flatbuffers::EndianScalar;
 
 #[allow(non_camel_case_types)]
+#[repr(i8)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum AnchorVariant {
+  Start = 0,
+  Middle = 1,
+  End = 2,
+
+}
+
+const ENUM_MIN_ANCHOR_VARIANT: i8 = 0;
+const ENUM_MAX_ANCHOR_VARIANT: i8 = 2;
+
+impl<'a> flatbuffers::Follow<'a> for AnchorVariant {
+  type Inner = Self;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    flatbuffers::read_scalar_at::<Self>(buf, loc)
+  }
+}
+
+impl flatbuffers::EndianScalar for AnchorVariant {
+  #[inline]
+  fn to_little_endian(self) -> Self {
+    let n = i8::to_le(self as i8);
+    let p = &n as *const i8 as *const AnchorVariant;
+    unsafe { *p }
+  }
+  #[inline]
+  fn from_little_endian(self) -> Self {
+    let n = i8::from_le(self as i8);
+    let p = &n as *const i8 as *const AnchorVariant;
+    unsafe { *p }
+  }
+}
+
+impl flatbuffers::Push for AnchorVariant {
+    type Output = AnchorVariant;
+    #[inline]
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        flatbuffers::emplace_scalar::<AnchorVariant>(dst, *self);
+    }
+}
+
+#[allow(non_camel_case_types)]
+const ENUM_VALUES_ANCHOR_VARIANT:[AnchorVariant; 3] = [
+  AnchorVariant::Start,
+  AnchorVariant::Middle,
+  AnchorVariant::End
+];
+
+#[allow(non_camel_case_types)]
+const ENUM_NAMES_ANCHOR_VARIANT:[&'static str; 3] = [
+    "Start",
+    "Middle",
+    "End"
+];
+
+pub fn enum_name_anchor_variant(e: AnchorVariant) -> &'static str {
+  let index: usize = e as usize;
+  ENUM_NAMES_ANCHOR_VARIANT[index]
+}
+
+#[allow(non_camel_case_types)]
+#[repr(i8)]
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum AnchorBias {
+  Left = 0,
+  Right = 1,
+
+}
+
+const ENUM_MIN_ANCHOR_BIAS: i8 = 0;
+const ENUM_MAX_ANCHOR_BIAS: i8 = 1;
+
+impl<'a> flatbuffers::Follow<'a> for AnchorBias {
+  type Inner = Self;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    flatbuffers::read_scalar_at::<Self>(buf, loc)
+  }
+}
+
+impl flatbuffers::EndianScalar for AnchorBias {
+  #[inline]
+  fn to_little_endian(self) -> Self {
+    let n = i8::to_le(self as i8);
+    let p = &n as *const i8 as *const AnchorBias;
+    unsafe { *p }
+  }
+  #[inline]
+  fn from_little_endian(self) -> Self {
+    let n = i8::from_le(self as i8);
+    let p = &n as *const i8 as *const AnchorBias;
+    unsafe { *p }
+  }
+}
+
+impl flatbuffers::Push for AnchorBias {
+    type Output = AnchorBias;
+    #[inline]
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        flatbuffers::emplace_scalar::<AnchorBias>(dst, *self);
+    }
+}
+
+#[allow(non_camel_case_types)]
+const ENUM_VALUES_ANCHOR_BIAS:[AnchorBias; 2] = [
+  AnchorBias::Left,
+  AnchorBias::Right
+];
+
+#[allow(non_camel_case_types)]
+const ENUM_NAMES_ANCHOR_BIAS:[&'static str; 2] = [
+    "Left",
+    "Right"
+];
+
+pub fn enum_name_anchor_bias(e: AnchorBias) -> &'static str {
+  let index: usize = e as usize;
+  ENUM_NAMES_ANCHOR_BIAS[index]
+}
+
+#[allow(non_camel_case_types)]
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Operation {
   NONE = 0,
   Edit = 1,
+  UpdateSelections = 2,
 
 }
 
 const ENUM_MIN_OPERATION: u8 = 0;
-const ENUM_MAX_OPERATION: u8 = 1;
+const ENUM_MAX_OPERATION: u8 = 2;
 
 impl<'a> flatbuffers::Follow<'a> for Operation {
   type Inner = Self;
@@ -257,15 +381,17 @@ impl flatbuffers::Push for Operation {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_OPERATION:[Operation; 2] = [
+const ENUM_VALUES_OPERATION:[Operation; 3] = [
   Operation::NONE,
-  Operation::Edit
+  Operation::Edit,
+  Operation::UpdateSelections
 ];
 
 #[allow(non_camel_case_types)]
-const ENUM_NAMES_OPERATION:[&'static str; 2] = [
+const ENUM_NAMES_OPERATION:[&'static str; 3] = [
     "NONE",
-    "Edit"
+    "Edit",
+    "UpdateSelections"
 ];
 
 pub fn enum_name_operation(e: Operation) -> &'static str {
@@ -274,6 +400,218 @@ pub fn enum_name_operation(e: Operation) -> &'static str {
 }
 
 pub struct OperationUnionTableOffset {}
+pub enum AnchorOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct Anchor<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Anchor<'a> {
+    type Inner = Anchor<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> Anchor<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Anchor {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args AnchorArgs<'args>) -> flatbuffers::WIPOffset<Anchor<'bldr>> {
+      let mut builder = AnchorBuilder::new(_fbb);
+      builder.add_offset(args.offset);
+      if let Some(x) = args.insertion_id { builder.add_insertion_id(x); }
+      builder.add_bias(args.bias);
+      builder.add_variant(args.variant);
+      builder.finish()
+    }
+
+    pub const VT_VARIANT: flatbuffers::VOffsetT = 4;
+    pub const VT_INSERTION_ID: flatbuffers::VOffsetT = 6;
+    pub const VT_OFFSET: flatbuffers::VOffsetT = 8;
+    pub const VT_BIAS: flatbuffers::VOffsetT = 10;
+
+  #[inline]
+  pub fn variant(&self) -> AnchorVariant {
+    self._tab.get::<AnchorVariant>(Anchor::VT_VARIANT, Some(AnchorVariant::Start)).unwrap()
+  }
+  #[inline]
+  pub fn insertion_id(&self) -> Option<&'a super::Timestamp> {
+    self._tab.get::<super::Timestamp>(Anchor::VT_INSERTION_ID, None)
+  }
+  #[inline]
+  pub fn offset(&self) -> u64 {
+    self._tab.get::<u64>(Anchor::VT_OFFSET, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn bias(&self) -> AnchorBias {
+    self._tab.get::<AnchorBias>(Anchor::VT_BIAS, Some(AnchorBias::Left)).unwrap()
+  }
+}
+
+pub struct AnchorArgs<'a> {
+    pub variant: AnchorVariant,
+    pub insertion_id: Option<&'a  super::Timestamp>,
+    pub offset: u64,
+    pub bias: AnchorBias,
+}
+impl<'a> Default for AnchorArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        AnchorArgs {
+            variant: AnchorVariant::Start,
+            insertion_id: None,
+            offset: 0,
+            bias: AnchorBias::Left,
+        }
+    }
+}
+pub struct AnchorBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> AnchorBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_variant(&mut self, variant: AnchorVariant) {
+    self.fbb_.push_slot::<AnchorVariant>(Anchor::VT_VARIANT, variant, AnchorVariant::Start);
+  }
+  #[inline]
+  pub fn add_insertion_id(&mut self, insertion_id: &'b  super::Timestamp) {
+    self.fbb_.push_slot_always::<&super::Timestamp>(Anchor::VT_INSERTION_ID, insertion_id);
+  }
+  #[inline]
+  pub fn add_offset(&mut self, offset: u64) {
+    self.fbb_.push_slot::<u64>(Anchor::VT_OFFSET, offset, 0);
+  }
+  #[inline]
+  pub fn add_bias(&mut self, bias: AnchorBias) {
+    self.fbb_.push_slot::<AnchorBias>(Anchor::VT_BIAS, bias, AnchorBias::Left);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> AnchorBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    AnchorBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<Anchor<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+pub enum SelectionOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct Selection<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Selection<'a> {
+    type Inner = Selection<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> Selection<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Selection {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args SelectionArgs<'args>) -> flatbuffers::WIPOffset<Selection<'bldr>> {
+      let mut builder = SelectionBuilder::new(_fbb);
+      if let Some(x) = args.end { builder.add_end(x); }
+      if let Some(x) = args.start { builder.add_start(x); }
+      builder.add_reversed(args.reversed);
+      builder.finish()
+    }
+
+    pub const VT_START: flatbuffers::VOffsetT = 4;
+    pub const VT_END: flatbuffers::VOffsetT = 6;
+    pub const VT_REVERSED: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub fn start(&self) -> Option<Anchor<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Anchor<'a>>>(Selection::VT_START, None)
+  }
+  #[inline]
+  pub fn end(&self) -> Option<Anchor<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<Anchor<'a>>>(Selection::VT_END, None)
+  }
+  #[inline]
+  pub fn reversed(&self) -> bool {
+    self._tab.get::<bool>(Selection::VT_REVERSED, Some(false)).unwrap()
+  }
+}
+
+pub struct SelectionArgs<'a> {
+    pub start: Option<flatbuffers::WIPOffset<Anchor<'a >>>,
+    pub end: Option<flatbuffers::WIPOffset<Anchor<'a >>>,
+    pub reversed: bool,
+}
+impl<'a> Default for SelectionArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        SelectionArgs {
+            start: None,
+            end: None,
+            reversed: false,
+        }
+    }
+}
+pub struct SelectionBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> SelectionBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_start(&mut self, start: flatbuffers::WIPOffset<Anchor<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Anchor>>(Selection::VT_START, start);
+  }
+  #[inline]
+  pub fn add_end(&mut self, end: flatbuffers::WIPOffset<Anchor<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Anchor>>(Selection::VT_END, end);
+  }
+  #[inline]
+  pub fn add_reversed(&mut self, reversed: bool) {
+    self.fbb_.push_slot::<bool>(Selection::VT_REVERSED, reversed, false);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> SelectionBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    SelectionBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<Selection<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
 pub enum EditOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
@@ -434,6 +772,106 @@ impl<'a: 'b, 'b> EditBuilder<'a, 'b> {
   }
 }
 
+pub enum UpdateSelectionsOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct UpdateSelections<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for UpdateSelections<'a> {
+    type Inner = UpdateSelections<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> UpdateSelections<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        UpdateSelections {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args UpdateSelectionsArgs<'args>) -> flatbuffers::WIPOffset<UpdateSelections<'bldr>> {
+      let mut builder = UpdateSelectionsBuilder::new(_fbb);
+      if let Some(x) = args.lamport_timestamp { builder.add_lamport_timestamp(x); }
+      if let Some(x) = args.selections { builder.add_selections(x); }
+      if let Some(x) = args.set_id { builder.add_set_id(x); }
+      builder.finish()
+    }
+
+    pub const VT_SET_ID: flatbuffers::VOffsetT = 4;
+    pub const VT_SELECTIONS: flatbuffers::VOffsetT = 6;
+    pub const VT_LAMPORT_TIMESTAMP: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub fn set_id(&self) -> Option<&'a super::Timestamp> {
+    self._tab.get::<super::Timestamp>(UpdateSelections::VT_SET_ID, None)
+  }
+  #[inline]
+  pub fn selections(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Selection<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Selection<'a>>>>>(UpdateSelections::VT_SELECTIONS, None)
+  }
+  #[inline]
+  pub fn lamport_timestamp(&self) -> Option<&'a super::Timestamp> {
+    self._tab.get::<super::Timestamp>(UpdateSelections::VT_LAMPORT_TIMESTAMP, None)
+  }
+}
+
+pub struct UpdateSelectionsArgs<'a> {
+    pub set_id: Option<&'a  super::Timestamp>,
+    pub selections: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Selection<'a >>>>>,
+    pub lamport_timestamp: Option<&'a  super::Timestamp>,
+}
+impl<'a> Default for UpdateSelectionsArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        UpdateSelectionsArgs {
+            set_id: None,
+            selections: None,
+            lamport_timestamp: None,
+        }
+    }
+}
+pub struct UpdateSelectionsBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> UpdateSelectionsBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_set_id(&mut self, set_id: &'b  super::Timestamp) {
+    self.fbb_.push_slot_always::<&super::Timestamp>(UpdateSelections::VT_SET_ID, set_id);
+  }
+  #[inline]
+  pub fn add_selections(&mut self, selections: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Selection<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(UpdateSelections::VT_SELECTIONS, selections);
+  }
+  #[inline]
+  pub fn add_lamport_timestamp(&mut self, lamport_timestamp: &'b  super::Timestamp) {
+    self.fbb_.push_slot_always::<&super::Timestamp>(UpdateSelections::VT_LAMPORT_TIMESTAMP, lamport_timestamp);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> UpdateSelectionsBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    UpdateSelectionsBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<UpdateSelections<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
 pub enum OperationEnvelopeOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
@@ -462,7 +900,6 @@ impl<'a> OperationEnvelope<'a> {
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
         args: &'args OperationEnvelopeArgs) -> flatbuffers::WIPOffset<OperationEnvelope<'bldr>> {
-            
       let mut builder = OperationEnvelopeBuilder::new(_fbb);
       if let Some(x) = args.operation { builder.add_operation(x); }
       builder.add_operation_type(args.operation_type);
@@ -485,6 +922,16 @@ impl<'a> OperationEnvelope<'a> {
   pub fn operation_as_edit(&'a self) -> Option<Edit> {
     if self.operation_type() == Operation::Edit {
       self.operation().map(|u| Edit::init_from_table(u))
+    } else {
+      None
+    }
+  }
+
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn operation_as_update_selections(&'a self) -> Option<UpdateSelections> {
+    if self.operation_type() == Operation::UpdateSelections {
+      self.operation().map(|u| UpdateSelections::init_from_table(u))
     } else {
       None
     }

--- a/memo_core/src/serialization/schema_generated.rs
+++ b/memo_core/src/serialization/schema_generated.rs
@@ -802,7 +802,6 @@ impl<'a> UpdateSelections<'a> {
         args: &'args UpdateSelectionsArgs<'args>) -> flatbuffers::WIPOffset<UpdateSelections<'bldr>> {
       let mut builder = UpdateSelectionsBuilder::new(_fbb);
       if let Some(x) = args.lamport_timestamp { builder.add_lamport_timestamp(x); }
-      if let Some(x) = args.local_timestamp { builder.add_local_timestamp(x); }
       if let Some(x) = args.selections { builder.add_selections(x); }
       if let Some(x) = args.set_id { builder.add_set_id(x); }
       builder.finish()
@@ -810,8 +809,7 @@ impl<'a> UpdateSelections<'a> {
 
     pub const VT_SET_ID: flatbuffers::VOffsetT = 4;
     pub const VT_SELECTIONS: flatbuffers::VOffsetT = 6;
-    pub const VT_LOCAL_TIMESTAMP: flatbuffers::VOffsetT = 8;
-    pub const VT_LAMPORT_TIMESTAMP: flatbuffers::VOffsetT = 10;
+    pub const VT_LAMPORT_TIMESTAMP: flatbuffers::VOffsetT = 8;
 
   #[inline]
   pub fn set_id(&self) -> Option<&'a super::Timestamp> {
@@ -822,10 +820,6 @@ impl<'a> UpdateSelections<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Selection<'a>>>>>(UpdateSelections::VT_SELECTIONS, None)
   }
   #[inline]
-  pub fn local_timestamp(&self) -> Option<&'a super::Timestamp> {
-    self._tab.get::<super::Timestamp>(UpdateSelections::VT_LOCAL_TIMESTAMP, None)
-  }
-  #[inline]
   pub fn lamport_timestamp(&self) -> Option<&'a super::Timestamp> {
     self._tab.get::<super::Timestamp>(UpdateSelections::VT_LAMPORT_TIMESTAMP, None)
   }
@@ -834,7 +828,6 @@ impl<'a> UpdateSelections<'a> {
 pub struct UpdateSelectionsArgs<'a> {
     pub set_id: Option<&'a  super::Timestamp>,
     pub selections: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Selection<'a >>>>>,
-    pub local_timestamp: Option<&'a  super::Timestamp>,
     pub lamport_timestamp: Option<&'a  super::Timestamp>,
 }
 impl<'a> Default for UpdateSelectionsArgs<'a> {
@@ -843,7 +836,6 @@ impl<'a> Default for UpdateSelectionsArgs<'a> {
         UpdateSelectionsArgs {
             set_id: None,
             selections: None,
-            local_timestamp: None,
             lamport_timestamp: None,
         }
     }
@@ -860,10 +852,6 @@ impl<'a: 'b, 'b> UpdateSelectionsBuilder<'a, 'b> {
   #[inline]
   pub fn add_selections(&mut self, selections: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Selection<'b >>>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(UpdateSelections::VT_SELECTIONS, selections);
-  }
-  #[inline]
-  pub fn add_local_timestamp(&mut self, local_timestamp: &'b  super::Timestamp) {
-    self.fbb_.push_slot_always::<&super::Timestamp>(UpdateSelections::VT_LOCAL_TIMESTAMP, local_timestamp);
   }
   #[inline]
   pub fn add_lamport_timestamp(&mut self, lamport_timestamp: &'b  super::Timestamp) {

--- a/memo_core/src/serialization/schema_generated.rs
+++ b/memo_core/src/serialization/schema_generated.rs
@@ -802,6 +802,7 @@ impl<'a> UpdateSelections<'a> {
         args: &'args UpdateSelectionsArgs<'args>) -> flatbuffers::WIPOffset<UpdateSelections<'bldr>> {
       let mut builder = UpdateSelectionsBuilder::new(_fbb);
       if let Some(x) = args.lamport_timestamp { builder.add_lamport_timestamp(x); }
+      if let Some(x) = args.local_timestamp { builder.add_local_timestamp(x); }
       if let Some(x) = args.selections { builder.add_selections(x); }
       if let Some(x) = args.set_id { builder.add_set_id(x); }
       builder.finish()
@@ -809,7 +810,8 @@ impl<'a> UpdateSelections<'a> {
 
     pub const VT_SET_ID: flatbuffers::VOffsetT = 4;
     pub const VT_SELECTIONS: flatbuffers::VOffsetT = 6;
-    pub const VT_LAMPORT_TIMESTAMP: flatbuffers::VOffsetT = 8;
+    pub const VT_LOCAL_TIMESTAMP: flatbuffers::VOffsetT = 8;
+    pub const VT_LAMPORT_TIMESTAMP: flatbuffers::VOffsetT = 10;
 
   #[inline]
   pub fn set_id(&self) -> Option<&'a super::Timestamp> {
@@ -820,6 +822,10 @@ impl<'a> UpdateSelections<'a> {
     self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Selection<'a>>>>>(UpdateSelections::VT_SELECTIONS, None)
   }
   #[inline]
+  pub fn local_timestamp(&self) -> Option<&'a super::Timestamp> {
+    self._tab.get::<super::Timestamp>(UpdateSelections::VT_LOCAL_TIMESTAMP, None)
+  }
+  #[inline]
   pub fn lamport_timestamp(&self) -> Option<&'a super::Timestamp> {
     self._tab.get::<super::Timestamp>(UpdateSelections::VT_LAMPORT_TIMESTAMP, None)
   }
@@ -828,6 +834,7 @@ impl<'a> UpdateSelections<'a> {
 pub struct UpdateSelectionsArgs<'a> {
     pub set_id: Option<&'a  super::Timestamp>,
     pub selections: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<Selection<'a >>>>>,
+    pub local_timestamp: Option<&'a  super::Timestamp>,
     pub lamport_timestamp: Option<&'a  super::Timestamp>,
 }
 impl<'a> Default for UpdateSelectionsArgs<'a> {
@@ -836,6 +843,7 @@ impl<'a> Default for UpdateSelectionsArgs<'a> {
         UpdateSelectionsArgs {
             set_id: None,
             selections: None,
+            local_timestamp: None,
             lamport_timestamp: None,
         }
     }
@@ -852,6 +860,10 @@ impl<'a: 'b, 'b> UpdateSelectionsBuilder<'a, 'b> {
   #[inline]
   pub fn add_selections(&mut self, selections: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Selection<'b >>>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(UpdateSelections::VT_SELECTIONS, selections);
+  }
+  #[inline]
+  pub fn add_local_timestamp(&mut self, local_timestamp: &'b  super::Timestamp) {
+    self.fbb_.push_slot_always::<&super::Timestamp>(UpdateSelections::VT_LOCAL_TIMESTAMP, local_timestamp);
   }
   #[inline]
   pub fn add_lamport_timestamp(&mut self, lamport_timestamp: &'b  super::Timestamp) {

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -804,6 +804,21 @@ impl Operation {
         }
     }
 
+    pub fn is_selection_update(&self) -> bool {
+        match self {
+            Operation::EpochOperation { operation, .. } => match operation {
+                epoch::Operation::BufferOperation { operations, .. } => {
+                    operations.iter().all(|buffer_op| match buffer_op {
+                        buffer::Operation::UpdateSelections { .. } => true,
+                        _ => false,
+                    })
+                }
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
     pub fn serialize(&self) -> Vec<u8> {
         let mut builder = FlatBufferBuilder::new();
         let root = self.to_flatbuf(&mut builder);

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -544,18 +544,18 @@ impl WorkTree {
         ))
     }
 
-    pub fn add_selection_set(
+    pub fn add_selection_set<I>(
         &self,
         buffer_id: BufferId,
-        selections: Vec<Selection>,
-    ) -> Result<(SelectionSetId, OperationEnvelope), Error> {
+        ranges: I,
+    ) -> Result<(SelectionSetId, OperationEnvelope), Error>
+    where
+        I: IntoIterator<Item = Range<Point>>,
+    {
         let file_id = self.buffer_file_id(buffer_id)?;
         let mut cur_epoch = self.cur_epoch_mut();
-        let (set_id, operation) = cur_epoch.add_selection_set(
-            file_id,
-            selections,
-            &mut self.lamport_clock.borrow_mut(),
-        )?;
+        let (set_id, operation) =
+            cur_epoch.add_selection_set(file_id, ranges, &mut self.lamport_clock.borrow_mut())?;
 
         Ok((
             set_id,

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -195,16 +195,21 @@ impl WorkTree {
             if let Some(observer) = self.observer.as_ref() {
                 for (buffer_id, file_id) in self.buffers.borrow().iter() {
                     let prev_version = prev_versions.remove(file_id).unwrap();
-                    observer.changed(
-                        *buffer_id,
-                        epoch.changes_since(*file_id, &prev_version)?.collect(),
-                        Self::selection_ranges_internal(
-                            &self.local_selection_sets.borrow(),
-                            &self.buffers.borrow(),
-                            &epoch,
+                    let changes: Vec<_> = epoch.changes_since(*file_id, &prev_version)?.collect();
+                    if !changes.is_empty()
+                        || epoch.selections_changed_since(*file_id, &prev_version)?
+                    {
+                        observer.changed(
                             *buffer_id,
-                        )?,
-                    );
+                            changes,
+                            Self::selection_ranges_internal(
+                                &self.local_selection_sets.borrow(),
+                                &self.buffers.borrow(),
+                                &epoch,
+                                *buffer_id,
+                            )?,
+                        );
+                    }
                 }
             }
 

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -68,8 +68,8 @@ pub struct LocalSelectionSetId(u32);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BufferSelectionRanges {
-    local: HashMap<LocalSelectionSetId, Vec<Range<Point>>>,
-    remote: HashMap<ReplicaId, Vec<Vec<Range<Point>>>>,
+    pub local: HashMap<LocalSelectionSetId, Vec<Range<Point>>>,
+    pub remote: HashMap<ReplicaId, Vec<Vec<Range<Point>>>>,
 }
 
 enum MaybeDone<F: Future> {

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -1,4 +1,4 @@
-use crate::buffer::{self, Change, Point, Text};
+use crate::buffer::{self, Buffer, Change};
 use crate::epoch::{self, Cursor, DirEntry, Epoch, FileId, FileType};
 use crate::serialization;
 use crate::{time, Error, Oid, ReplicaId};
@@ -10,7 +10,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io;
 use std::mem;
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -159,13 +158,18 @@ impl WorkTree {
 
             let mut prev_versions = HashMap::new();
             for file_id in self.buffers.borrow().values() {
-                prev_versions.insert(*file_id, epoch.buffer_version(*file_id));
+                prev_versions.insert(
+                    *file_id,
+                    epoch.with_buffer(*file_id, |buf| Ok(buf.version.clone()))?,
+                );
             }
 
             let fixup_ops = mutate(&mut epoch)?;
             for (buffer_id, file_id) in self.buffers.borrow().iter() {
+                let prev_version = prev_versions.remove(file_id).unwrap();
                 let mut changes = epoch
-                    .changes_since(*file_id, prev_versions.remove(file_id).unwrap().unwrap())?
+                    .with_buffer(*file_id, |buf| Ok(buf.changes_since(prev_version)))
+                    .unwrap()
                     .peekable();
                 if changes.peek().is_some() {
                     if let Some(observer) = self.observer.as_ref() {
@@ -407,6 +411,29 @@ impl WorkTree {
         None
     }
 
+    pub fn with_buffer<F, T>(&self, buffer_id: BufferId, f: F) -> Result<T, Error>
+    where
+        F: FnOnce(&Buffer) -> Result<T, Error>,
+    {
+        let buffer_file_id = self.buffer_file_id(buffer_id)?;
+        self.cur_epoch().with_buffer(buffer_file_id, f)
+    }
+
+    pub fn with_buffer_mut<F, I>(&self, buffer_id: BufferId, mutate: F) -> Result<Operation, Error>
+    where
+        F: FnOnce(&mut Buffer, &mut time::Local, &mut time::Lamport) -> Result<I, Error>,
+        I: IntoIterator<Item = buffer::Operation>,
+    {
+        let buffer_file_id = self.buffer_file_id(buffer_id)?;
+        let mut epoch = self.cur_epoch_mut();
+        let operation =
+            epoch.with_buffer_mut(buffer_file_id, &mut self.lamport_clock.borrow_mut(), mutate)?;
+        Ok(Operation::EpochOperation {
+            epoch_id: epoch.id,
+            operation,
+        })
+    }
+
     fn base_text(
         path: &Path,
         epoch: &RefCell<Epoch>,
@@ -429,81 +456,11 @@ impl WorkTree {
         }
     }
 
-    pub fn edit<I, T>(
-        &self,
-        buffer_id: BufferId,
-        old_ranges: I,
-        new_text: T,
-    ) -> Result<Operation, Error>
-    where
-        I: IntoIterator<Item = Range<usize>>,
-        T: Into<Text>,
-    {
-        let file_id = self.buffer_file_id(buffer_id)?;
-        let mut cur_epoch = self.cur_epoch_mut();
-        let epoch_id = cur_epoch.id;
-        let operation = cur_epoch
-            .edit(
-                file_id,
-                old_ranges,
-                new_text,
-                &mut self.lamport_clock.borrow_mut(),
-            )
-            .unwrap();
-
-        Ok(Operation::EpochOperation {
-            epoch_id,
-            operation,
-        })
-    }
-
-    pub fn edit_2d<I, T>(
-        &self,
-        buffer_id: BufferId,
-        old_ranges: I,
-        new_text: T,
-    ) -> Result<Operation, Error>
-    where
-        I: IntoIterator<Item = Range<Point>>,
-        T: Into<Text>,
-    {
-        let file_id = self.buffer_file_id(buffer_id)?;
-        let mut cur_epoch = self.cur_epoch_mut();
-        let epoch_id = cur_epoch.id;
-        let operation = cur_epoch
-            .edit_2d(
-                file_id,
-                old_ranges,
-                new_text,
-                &mut self.lamport_clock.borrow_mut(),
-            )
-            .unwrap();
-
-        Ok(Operation::EpochOperation {
-            epoch_id,
-            operation,
-        })
-    }
-
     pub fn path(&self, buffer_id: BufferId) -> Option<PathBuf> {
         self.buffers
             .borrow()
             .get(&buffer_id)
             .and_then(|file_id| self.cur_epoch().path(*file_id))
-    }
-
-    pub fn text(&self, buffer_id: BufferId) -> Result<buffer::Iter, Error> {
-        let file_id = self.buffer_file_id(buffer_id)?;
-        self.cur_epoch().text(file_id)
-    }
-
-    pub fn changes_since(
-        &self,
-        buffer_id: BufferId,
-        version: time::Global,
-    ) -> Result<impl Iterator<Item = buffer::Change>, Error> {
-        let file_id = self.buffer_file_id(buffer_id)?;
-        self.cur_epoch().changes_since(file_id, version)
     }
 
     fn cur_epoch(&self) -> Ref<Epoch> {
@@ -768,11 +725,17 @@ impl Future for SwitchEpoch {
                             operation,
                         });
                         to_assign.open_text_file(new_file_id, "", &mut lamport_clock)?;
-                        let operation = to_assign.edit(
+                        let operation = to_assign.with_buffer_mut(
                             new_file_id,
-                            Some(0..0),
-                            cur_epoch.text(buffers[&buffer_id])?.into_string().as_str(),
                             &mut lamport_clock,
+                            |buffer, local_clock, lamport_clock| {
+                                Ok(buffer.edit(
+                                    Some(0..0),
+                                    buffer.to_string().as_str(),
+                                    local_clock,
+                                    lamport_clock,
+                                ))
+                            },
                         )?;
                         fixup_ops.push(Operation::EpochOperation {
                             epoch_id: to_assign.id,
@@ -792,8 +755,9 @@ impl Future for SwitchEpoch {
 
                 let mut buffer_changes = Vec::new();
                 for (buffer_id, new_file_id) in buffer_mappings {
-                    let old_text = cur_epoch.text(buffers[&buffer_id])?.into_string();
-                    let new_text = to_assign.text(new_file_id)?.into_string();
+                    let old_file_id = buffers[&buffer_id];
+                    let old_text = cur_epoch.with_buffer(old_file_id, |buf| Ok(buf.to_string()))?;
+                    let new_text = to_assign.with_buffer(new_file_id, |buf| Ok(buf.to_string()))?;
                     let mut changes = buffer::diff(&old_text, &new_text).peekable();
                     if changes.peek().is_some() {
                         buffer_changes.push((buffer_id, changes));
@@ -960,7 +924,8 @@ mod tests {
                 for buffer_id in tree.open_buffers() {
                     assert_eq!(
                         observer.text(buffer_id),
-                        tree.text(buffer_id).unwrap().into_string()
+                        tree.with_buffer(buffer_id, |buf| Ok(buf.to_string()))
+                            .unwrap()
                     );
                 }
             }
@@ -973,14 +938,26 @@ mod tests {
         let base_tree = WorkTree::empty();
         base_tree.create_file("a", FileType::Text).unwrap();
         let a_base = base_tree.open_text_file("a").wait().unwrap();
-        base_tree.edit(a_base, Some(0..0), "abc").unwrap();
+        base_tree
+            .with_buffer_mut(a_base, |buffer, local_clock, lamport_clock| {
+                Ok(buffer.edit(Some(0..0), "abc", local_clock, lamport_clock))
+            })
+            .unwrap();
         let commit_0 = git.commit(&base_tree);
 
-        base_tree.edit(a_base, Some(1..2), "def").unwrap();
+        base_tree
+            .with_buffer_mut(a_base, |buffer, local_clock, lamport_clock| {
+                Ok(buffer.edit(Some(1..2), "def", local_clock, lamport_clock))
+            })
+            .unwrap();
         base_tree.create_file("b", FileType::Directory).unwrap();
         let commit_1 = git.commit(&base_tree);
 
-        base_tree.edit(a_base, Some(2..3), "ghi").unwrap();
+        base_tree
+            .with_buffer_mut(a_base, |buffer, local_clock, lamport_clock| {
+                Ok(buffer.edit(Some(2..3), "ghi", local_clock, lamport_clock))
+            })
+            .unwrap();
         base_tree.create_file("b/c", FileType::Text).unwrap();
         let commit_2 = git.commit(&base_tree);
 
@@ -1044,7 +1021,10 @@ mod tests {
             fn text_changed(&self, buffer_id: BufferId, _: Box<Iterator<Item = Change>>) {
                 // Assume that users of WorkTree can always acquire a mutable reference to it.
                 let tree = unsafe { self.0.as_ptr().as_mut().unwrap() };
-                tree.edit(buffer_id, Some(0..0), "!").unwrap();
+                tree.with_buffer_mut(buffer_id, |buffer, local_clock, lamport_clock| {
+                    Ok(buffer.edit(Some(0..0), "!", local_clock, lamport_clock))
+                })
+                .unwrap();
             }
         }
 
@@ -1053,10 +1033,18 @@ mod tests {
         base_tree.create_file("a", FileType::Text).unwrap();
         let a_base = base_tree.open_text_file("a").wait().unwrap();
 
-        base_tree.edit(a_base, Some(0..0), "abc").unwrap();
+        base_tree
+            .with_buffer_mut(a_base, |buffer, local_clock, lamport_clock| {
+                Ok(buffer.edit(Some(0..0), "abc", local_clock, lamport_clock))
+            })
+            .unwrap();
         let commit_0 = git.commit(&base_tree);
 
-        base_tree.edit(a_base, Some(3..3), "def").unwrap();
+        base_tree
+            .with_buffer_mut(a_base, |buffer, local_clock, lamport_clock| {
+                Ok(buffer.edit(Some(3..3), "def", local_clock, lamport_clock))
+            })
+            .unwrap();
         let commit_1 = git.commit(&base_tree);
 
         let (tree_1, ops_1) = WorkTree::new(
@@ -1085,7 +1073,11 @@ mod tests {
         let buffer_id_2 = tree_2.open_text_file("a").wait().unwrap();
 
         // Synchronous re-entrant calls from the observer don't throw errors.
-        let edit_op = tree_2.edit(buffer_id_2, Some(0..0), "x").unwrap();
+        let edit_op = base_tree
+            .with_buffer_mut(buffer_id_2, |buffer, local_clock, lamport_clock| {
+                Ok(buffer.edit(Some(0..0), "x", local_clock, lamport_clock))
+            })
+            .unwrap();
         tree_1
             .borrow_mut()
             .apply_ops(Some(edit_op))
@@ -1139,7 +1131,8 @@ mod tests {
         }
 
         fn text_str(&self, buffer_id: BufferId) -> String {
-            self.text(buffer_id).unwrap().into_string()
+            self.with_buffer(buffer_id, |buf| Ok(buf.to_string()))
+                .unwrap()
         }
 
         fn randomly_mutate<T: Rng>(&self, rng: &mut T, count: usize) -> Vec<Operation> {
@@ -1277,7 +1270,10 @@ mod tests {
                             .map_err(|_| {
                                 io::Error::new(io::ErrorKind::Other, "Path does not exist")
                             })
-                            .map(|buffer_id| tree.text(buffer_id).unwrap().into_string())
+                            .map(|buffer_id| {
+                                tree.with_buffer(buffer_id, |buf| Ok(buf.to_string()))
+                                    .unwrap()
+                            })
                     })
                     .into_future(),
             )
@@ -1294,7 +1290,9 @@ mod tests {
         }
 
         fn opened_buffer(&self, buffer_id: BufferId, tree: &WorkTree) {
-            let text = tree.text(buffer_id).unwrap().collect::<Vec<u16>>();
+            let text = tree
+                .with_buffer(buffer_id, |buf| Ok(buf.to_string()))
+                .unwrap();
             self.buffers
                 .borrow_mut()
                 .insert(buffer_id, buffer::Buffer::new(text));

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -150,7 +150,7 @@ impl WorkTree {
         ))
     }
 
-    fn mutate_cur_epoch<'a, F>(&'a self, mutate: F) -> Result<Vec<Operation>, Error>
+    fn mutate_cur_epoch<F>(&self, mutate: F) -> Result<Vec<Operation>, Error>
     where
         F: FnOnce(&mut Epoch) -> Result<Vec<epoch::Operation>, Error>,
     {

--- a/memo_js/README.md
+++ b/memo_js/README.md
@@ -146,17 +146,24 @@ const removeSetOp = buffer.removeSelectionSet(set);
 broadcast([editOp1, editOp2, createSetOp, replaceSetOp, removeSetOp]);
 ```
 
-As you incorporate operations received from other peers, you may want to use `Buffer.prototype.onTextChange` and `Buffer.prototype.onSelectionsChange` to keep an external representation of the buffer up-to-date:
+As you incorporate operations received from other peers, you may want to use `Buffer.prototype.onChange` to keep an external representation of the buffer up-to-date:
 
 ```ts
-buffer.onTextChange(changes => {
-  for (const change of changes) {
-    console.log(change); // => { start: { row: 0, column: 0 }, end: { row: 0, column: 5 }, text: "Goodbye" }
-    externalBuffer.edit(change.start, change.end, change.text);
+buffer.onChange(change => {
+  for (const textChange of change.textChanges) {
+    console.log(textChange); // => { start: { row: 0, column: 0 }, end: { row: 0, column: 5 }, text: "Goodbye" }
+    externalBuffer.edit(textChange.start, textChange.end, textChange.text);
   }
-});
-buffer.onSelectionsChange(() => {
-  console.log(buffer.getSelections());
+  console.log(change.selectionRanges); /* => {
+    local: {
+      1: [{ start: { row: 0, column: 2 }, end: { row: 0, column: 3 } }]
+    },
+    remote: {
+      "65242244-9706-4b42-9785-fa5cbe5d5709": [
+        [{ start: { row: 0, column: 2 }, end: { row: 0, column: 3 } }]
+      ]
+    }
+  }*/
 });
 ```
 

--- a/memo_js/README.md
+++ b/memo_js/README.md
@@ -12,10 +12,15 @@ Memo allows multiple remote collaborators to share the state of a single Git wor
 Both scenarios are automatically handled when you call `WorkTree.create`:
 
 ```ts
-const replicaId = generateUUID()
+const replicaId = generateUUID();
 const baseCommitOID = "8251a3c491b3884d7f828d2a1c5c565855171a2c";
 const startOps = await fetchInitialOperations();
-const [tree, ops] = await WorkTree.create(replicaId, baseCommitOID, startOps, gitProvider);
+const [tree, ops] = await WorkTree.create(
+  replicaId,
+  baseCommitOID,
+  startOps,
+  gitProvider
+);
 broadcast(ops);
 ```
 
@@ -118,18 +123,40 @@ const editOp2 = buffer.edit(
   [{ start: { row: 0, column: 10 }, end: { row: 0, column: 12 } }],
   "ms"
 );
-broadcast([editOp1, editOp2]);
 console.log(buffer.getText()); // ==> "Hello worms"
+
+const [set, createSetOp] = buffer.addSelectionSet([
+  { start: point(0, 0), end: point(0, 1) }
+]);
+const replaceSetOp = buffer.replaceSelectionSet(set, [
+  { start: point(0, 2), end: point(0, 3) }
+]);
+console.log(buffer.getSelections()); /* => {
+  local: {
+    1: [{ start: { row: 0, column: 2 }, end: { row: 0, column: 3 } }]
+  },
+  remote: {
+    "65242244-9706-4b42-9785-fa5cbe5d5709": [
+      [{ start: { row: 0, column: 2 }, end: { row: 0, column: 3 } }]
+    ]
+  }
+}*/
+
+const removeSetOp = buffer.removeSelectionSet(set);
+broadcast([editOp1, editOp2, createSetOp, replaceSetOp, removeSetOp]);
 ```
 
-As you incorporate operations received from other peers, you may want to use `Buffer.prototype.onChange` to keep an external representation of the buffer up-to-date:
+As you incorporate operations received from other peers, you may want to use `Buffer.prototype.onTextChange` and `Buffer.prototype.onSelectionsChange` to keep an external representation of the buffer up-to-date:
 
 ```ts
-buffer.onChange(changes => {
+buffer.onTextChange(changes => {
   for (const change of changes) {
     console.log(change); // => { start: { row: 0, column: 0 }, end: { row: 0, column: 5 }, text: "Goodbye" }
     externalBuffer.edit(change.start, change.end, change.text);
   }
+});
+buffer.onSelectionsChange(() => {
+  console.log(buffer.getSelections());
 });
 ```
 
@@ -141,7 +168,7 @@ If you want to reset the work tree to a different (possibly `null`) base (e.g. a
 const commitOid = "70403cdf91c2e6fbf76167f725935e6b0993eeb1";
 const resetOps = tree.reset(commitOid);
 await broadcast(resetOps);
-console.log(tree.head()) // => 70403cdf91c2e6fbf76167f725935e6b0993eeb1
+console.log(tree.head()); // => 70403cdf91c2e6fbf76167f725935e6b0993eeb1
 ```
 
 This resets you and all the other peers to the new commit. Note that this is an asynchronous action, as the tree needs to perform I/O in order to retrieve the new base entries.
@@ -163,7 +190,7 @@ export interface OperationEnvelope {
 }
 ```
 
-Technically, to synchronize with other peers, you only need to transmit the  operation that is stored inside of the envelope; so, why including those extra timestamp and replica id fields?
+Technically, to synchronize with other peers, you only need to transmit the operation that is stored inside of the envelope; so, why including those extra timestamp and replica id fields?
 
 You may recall the `fetchInitialOperations` function that we called when [creating a new `WorkTree`](#creating-a-worktree). It turns out that, in order to instantiate a new `WorkTree`, you only need operations associated with the _latest_ epoch. By exposing the epoch timestamp and replica id, we allow you to store operations such that they can be efficiently queried later when instantiating new work trees:
 

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -49,6 +49,7 @@ export interface OperationEnvelope {
   epochReplicaId(): ReplicaId;
   epochHead(): null | Oid;
   operation(): Operation;
+  isSelectionUpdate(): boolean;
 }
 
 export enum FileStatus {

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -193,7 +193,19 @@ export class Buffer {
   }
 
   getSelections(): Selections {
-    return this.tree.selections(this.id);
+    const selections = this.tree.selections(this.id);
+
+    const local = new Map();
+    for (const setId in selections.local) {
+      local.set(setId, selections.local[setId]);
+    }
+
+    const remote = new Map();
+    for (const replicaId in selections.remote) {
+      remote.set(replicaId, selections.remote[replicaId]);
+    }
+
+    return { local, remote };
   }
 
   onTextChange(callback: TextChangeObserverCallback): Disposable {

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -6,10 +6,11 @@ use memo_core as memo;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_derive::{Deserialize, Serialize};
 use std::cell::Cell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::marker::PhantomData;
 use std::mem;
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use wasm_bindgen::{prelude::*, JsCast};
@@ -17,6 +18,7 @@ use wasm_bindgen_futures::{future_to_promise, JsFuture};
 
 trait JsValueExt {
     fn into_operation(self) -> Result<Option<memo::Operation>, JsValue>;
+    fn into_ranges_vec(self) -> Result<Vec<Range<memo::Point>>, JsValue>;
     fn into_error_message(self) -> Result<String, String>;
 }
 
@@ -49,13 +51,13 @@ pub struct WorkTreeNewResult {
 }
 
 #[wasm_bindgen]
-pub struct OperationEnvelope(memo::OperationEnvelope);
-
-#[derive(Copy, Clone, Serialize, Deserialize)]
-struct EditRange {
-    start: memo::Point,
-    end: memo::Point,
+pub struct AddSelectionSetResult {
+    set_id: memo::LocalSelectionSetId,
+    operation: Option<OperationEnvelope>,
 }
+
+#[wasm_bindgen]
+pub struct OperationEnvelope(memo::OperationEnvelope);
 
 #[derive(Serialize)]
 struct Change {
@@ -73,6 +75,18 @@ struct Entry {
     path: String,
     status: memo::FileStatus,
     visible: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+struct JsRange {
+    start: memo::Point,
+    end: memo::Point,
+}
+
+#[derive(Deserialize, Serialize)]
+struct JsSelections {
+    local: HashMap<memo::LocalSelectionSetId, Vec<JsRange>>,
+    remote: HashMap<memo::ReplicaId, Vec<Vec<JsRange>>>,
 }
 
 pub struct HexOid(memo::Oid);
@@ -96,6 +110,9 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = textChanged)]
     fn text_changed(this: &ChangeObserver, buffer_id: JsValue, changes: JsValue);
+
+    #[wasm_bindgen(method, js_name = selectionsChanged)]
+    fn selections_changed(this: &ChangeObserver, buffer_id: JsValue);
 }
 
 #[wasm_bindgen]
@@ -257,16 +274,68 @@ impl WorkTree {
         new_text: &str,
     ) -> Result<OperationEnvelope, JsValue> {
         let buffer_id = buffer_id.into_serde().map_err(|e| e.into_js_err())?;
-        let old_ranges = old_ranges
-            .into_serde::<Vec<EditRange>>()
-            .map_err(|e| e.into_js_err())?
-            .into_iter()
-            .map(|EditRange { start, end }| start..end);
-
+        let old_ranges = old_ranges.into_ranges_vec()?;
         self.0
             .edit_2d(buffer_id, old_ranges, new_text)
             .map(|op| OperationEnvelope::new(op))
             .map_err(|e| e.into_js_err())
+    }
+
+    pub fn add_selection_set(
+        &self,
+        buffer_id: JsValue,
+        ranges: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let buffer_id = buffer_id.into_serde().map_err(|e| e.into_js_err())?;
+        let ranges = ranges.into_ranges_vec()?;
+        let (set_id, op) = self
+            .0
+            .add_selection_set(buffer_id, ranges)
+            .map_err(|e| e.into_js_err())?;
+        Ok(JsValue::from(AddSelectionSetResult {
+            set_id,
+            operation: Some(OperationEnvelope::new(op)),
+        }))
+    }
+
+    pub fn replace_selection_set(
+        &self,
+        buffer_id: JsValue,
+        set_id: JsValue,
+        ranges: JsValue,
+    ) -> Result<OperationEnvelope, JsValue> {
+        let buffer_id = buffer_id.into_serde().map_err(|e| e.into_js_err())?;
+        let set_id = set_id.into_serde().map_err(|e| e.into_js_err())?;
+        let ranges = ranges.into_ranges_vec()?;
+        let op = self
+            .0
+            .replace_selection_set(buffer_id, set_id, ranges)
+            .map_err(|e| e.into_js_err())?;
+        Ok(OperationEnvelope::new(op))
+    }
+
+    pub fn remove_selection_set(
+        &self,
+        buffer_id: JsValue,
+        set_id: JsValue,
+    ) -> Result<OperationEnvelope, JsValue> {
+        let buffer_id = buffer_id.into_serde().map_err(|e| e.into_js_err())?;
+        let set_id = set_id.into_serde().map_err(|e| e.into_js_err())?;
+        let op = self
+            .0
+            .remove_selection_set(buffer_id, set_id)
+            .map_err(|e| e.into_js_err())?;
+        Ok(OperationEnvelope::new(op))
+    }
+
+    pub fn selections(&self, buffer_id: JsValue) -> Result<JsValue, JsValue> {
+        let buffer_id = buffer_id.into_serde().map_err(|e| e.into_js_err())?;
+        let selections = self
+            .0
+            .selection_ranges(buffer_id)
+            .map_err(|e| e.into_js_err())?;
+        let js_selections = JsSelections::from(selections);
+        Ok(JsValue::from_serde(&js_selections).unwrap())
     }
 
     pub fn entries(&self, descend_into: JsValue, show_deleted: bool) -> Result<JsValue, JsValue> {
@@ -309,6 +378,19 @@ impl WorkTreeNewResult {
         self.operations
             .take()
             .ok_or(js_sys::Error::new("Cannot take operations twice").into())
+    }
+}
+
+#[wasm_bindgen]
+impl AddSelectionSetResult {
+    pub fn set_id(&mut self) -> JsValue {
+        JsValue::from_serde(&self.set_id).unwrap()
+    }
+
+    pub fn operation(&mut self) -> Result<OperationEnvelope, JsValue> {
+        self.operation
+            .take()
+            .ok_or(js_sys::Error::new("Cannot take operation twice").into())
     }
 }
 
@@ -463,8 +545,9 @@ impl memo::GitProvider for GitProviderWrapper {
 }
 
 impl memo::ChangeObserver for ChangeObserver {
-    fn text_changed(&self, buffer_id: memo::BufferId, changes: Box<Iterator<Item = memo::Change>>) {
+    fn text_changed(&self, buffer_id: memo::BufferId, changes: Vec<memo::Change>) {
         let changes = changes
+            .into_iter()
             .map(|change| Change {
                 start: change.range.start,
                 end: change.range.end,
@@ -476,6 +559,45 @@ impl memo::ChangeObserver for ChangeObserver {
             JsValue::from_serde(&buffer_id).unwrap(),
             JsValue::from_serde(&changes).unwrap(),
         );
+    }
+
+    fn selections_changed(&self, buffer_id: memo::BufferId) {
+        ChangeObserver::selections_changed(self, JsValue::from_serde(&buffer_id).unwrap());
+    }
+}
+
+impl From<memo::BufferSelectionRanges> for JsSelections {
+    fn from(selections: memo::BufferSelectionRanges) -> Self {
+        let mut js_selections = JsSelections {
+            local: HashMap::new(),
+            remote: HashMap::new(),
+        };
+
+        for (set_id, ranges) in selections.local {
+            js_selections.local.insert(
+                set_id,
+                ranges.into_iter().map(|range| range.into()).collect(),
+            );
+        }
+
+        for (replica_id, sets) in selections.remote {
+            let js_sets = sets
+                .into_iter()
+                .map(|ranges| ranges.into_iter().map(|range| range.into()).collect())
+                .collect();
+            js_selections.remote.insert(replica_id, js_sets);
+        }
+
+        js_selections
+    }
+}
+
+impl From<Range<memo::Point>> for JsRange {
+    fn from(range: Range<memo::Point>) -> Self {
+        JsRange {
+            start: range.start,
+            end: range.end,
+        }
     }
 }
 
@@ -523,6 +645,15 @@ impl JsValueExt for JsValue {
         let mut bytes = Vec::with_capacity(js_bytes.byte_length() as usize);
         js_bytes.for_each(&mut |byte, _, _| bytes.push(byte));
         memo::Operation::deserialize(&bytes).map_err(|e| e.into_js_err())
+    }
+
+    fn into_ranges_vec(self) -> Result<Vec<Range<memo::Point>>, JsValue> {
+        Ok(self
+            .into_serde::<Vec<JsRange>>()
+            .map_err(|e| e.into_js_err())?
+            .into_iter()
+            .map(|JsRange { start, end }| start..end)
+            .collect())
     }
 
     fn into_error_message(self) -> Result<String, String> {

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -430,6 +430,11 @@ impl OperationEnvelope {
     pub fn operation(&self) -> Vec<u8> {
         self.0.operation.serialize()
     }
+
+    #[wasm_bindgen(js_name = isSelectionUpdate)]
+    pub fn is_selection_update(&self) -> bool {
+        self.0.operation.is_selection_update()
+    }
 }
 
 impl<T> AsyncIteratorToStream<T> {

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -206,10 +206,9 @@ impl WorkTree {
     }
 
     pub fn text(&self, buffer_id: JsValue) -> Result<JsValue, JsValue> {
-        let buffer_id = buffer_id.into_serde().map_js_err()?;
         self.0
-            .with_buffer(buffer_id, |buf| Ok(buf.to_string()))
-            .map(|text| JsValue::from_str(&text))
+            .text(buffer_id.into_serde().map_js_err()?)
+            .map(|text| JsValue::from_str(&text.into_string()))
             .map_js_err()
     }
 
@@ -227,9 +226,7 @@ impl WorkTree {
             .map(|EditRange { start, end }| start..end);
 
         self.0
-            .with_buffer_mut(buffer_id, |buf, local_clock, lamport_clock| {
-                Ok(buf.edit_2d(old_ranges, new_text, local_clock, lamport_clock))
-            })
+            .edit_2d(buffer_id, old_ranges, new_text)
             .map(|op| OperationEnvelope::new(op))
             .map_js_err()
     }

--- a/memo_js/src/support.ts
+++ b/memo_js/src/support.ts
@@ -52,7 +52,10 @@ export class AsyncIteratorWrapper<T> {
   }
 }
 
-export type ChangeObserverCallback = (changes: ReadonlyArray<Change>) => void;
+export type TextChangeObserverCallback = (
+  changes: ReadonlyArray<Change>
+) => void;
+export type SelectionsChangeObserverCallback = () => void;
 
 export class ChangeObserver {
   emitter: Emitter;
@@ -61,12 +64,23 @@ export class ChangeObserver {
     this.emitter = new Emitter();
   }
 
-  onChange(bufferId: BufferId, callback: ChangeObserverCallback): Disposable {
-    return this.emitter.on(`buffer-${bufferId}-change`, callback);
+  onTextChange(
+    bufferId: BufferId,
+    callback: TextChangeObserverCallback
+  ): Disposable {
+    return this.emitter.on(`buffer-${bufferId}-text-change`, callback);
+  }
+
+  onSelectionsChange(bufferId: BufferId, callback: SelectionsChangeObserverCallback): Disposable {
+    return this.emitter.on(`buffer-${bufferId}-selections-change`, callback);
   }
 
   textChanged(bufferId: BufferId, changes: Change[]) {
-    this.emitter.emit(`buffer-${bufferId}-change`, changes);
+    this.emitter.emit(`buffer-${bufferId}-text-change`, changes);
+  }
+
+  selectionsChanged(bufferId: BufferId) {
+    this.emitter.emit(`buffer-${bufferId}-selections-change`, {});
   }
 }
 

--- a/memo_js/src/support.ts
+++ b/memo_js/src/support.ts
@@ -1,7 +1,9 @@
 export type Tagged<BaseType, TagName> = BaseType & { __tag: TagName };
 export type Oid = string;
 export type Path = string;
+export type ReplicaId = Tagged<string, "ReplicaId">;
 export type BufferId = Tagged<number, "BufferId">;
+export type SelectionSetId = Tagged<number, "SelectionSetId">;
 export type Point = { row: number; column: number };
 export type Range = { start: Point; end: Point };
 export type Change = Range & { text: string };
@@ -20,6 +22,16 @@ export enum FileType {
 export interface GitProvider {
   baseEntries(oid: Oid): AsyncIterable<BaseEntry>;
   baseText(oid: Oid, path: Path): Promise<string>;
+}
+
+export interface SelectionRanges {
+  local: Map<SelectionSetId, Array<Range>>;
+  remote: Map<ReplicaId, Array<Array<Range>>>;
+}
+
+interface MemoSelectionRanges {
+  local: { [setId: number]: Array<Range> };
+  remote: { [replicaId: string]: Array<Array<Range>> };
 }
 
 export class GitProviderWrapper {
@@ -52,10 +64,12 @@ export class AsyncIteratorWrapper<T> {
   }
 }
 
-export type TextChangeObserverCallback = (
-  changes: ReadonlyArray<Change>
+export type ChangeObserverCallback = (
+  change: {
+    textChanges: ReadonlyArray<Change>;
+    selectionRanges: SelectionRanges;
+  }
 ) => void;
-export type SelectionsChangeObserverCallback = () => void;
 
 export class ChangeObserver {
   emitter: Emitter;
@@ -64,24 +78,36 @@ export class ChangeObserver {
     this.emitter = new Emitter();
   }
 
-  onTextChange(
+  onChange(bufferId: BufferId, callback: ChangeObserverCallback): Disposable {
+    return this.emitter.on(`buffer-${bufferId}-change`, callback);
+  }
+
+  changed(
     bufferId: BufferId,
-    callback: TextChangeObserverCallback
-  ): Disposable {
-    return this.emitter.on(`buffer-${bufferId}-text-change`, callback);
+    textChanges: Change[],
+    selectionRanges: MemoSelectionRanges
+  ) {
+    this.emitter.emit(`buffer-${bufferId}-change`, {
+      textChanges,
+      selectionRanges: fromMemoSelectionRanges(selectionRanges)
+    });
+  }
+}
+
+export function fromMemoSelectionRanges(
+  ranges: MemoSelectionRanges
+): SelectionRanges {
+  const local = new Map();
+  for (const setId in ranges.local) {
+    local.set(setId, ranges.local[setId]);
   }
 
-  onSelectionsChange(bufferId: BufferId, callback: SelectionsChangeObserverCallback): Disposable {
-    return this.emitter.on(`buffer-${bufferId}-selections-change`, callback);
+  const remote = new Map();
+  for (const replicaId in ranges.remote) {
+    remote.set(replicaId, ranges.remote[replicaId]);
   }
 
-  textChanged(bufferId: BufferId, changes: Change[]) {
-    this.emitter.emit(`buffer-${bufferId}-text-change`, changes);
-  }
-
-  selectionsChanged(bufferId: BufferId) {
-    this.emitter.emit(`buffer-${bufferId}-selections-change`, {});
-  }
+  return { local, remote };
 }
 
 export interface Disposable {

--- a/memo_js/test/tests.ts
+++ b/memo_js/test/tests.ts
@@ -348,6 +348,24 @@ suite("WorkTree", () => {
     }
   });
 
+  test("isSelectionUpdate", async () => {
+    const git = new TestGitProvider();
+    const [tree] = await WorkTree.create(uuid(), null, [], git);
+
+    const envelope1 = tree.createFile("file", FileType.Text);
+    assert(!envelope1.isSelectionUpdate());
+
+    const buffer1 = await tree.openTextFile("file");
+    const envelope2 = buffer1.edit(
+      [{ start: point(0, 0), end: point(0, 0) }],
+      "abc"
+    );
+    assert(!envelope2.isSelectionUpdate());
+
+    const [, envelope3] = buffer1.addSelectionSet([]);
+    assert(envelope3.isSelectionUpdate());
+  });
+
   test("versions", async () => {
     const OID = "0".repeat(40);
 

--- a/memo_js/test/tests.ts
+++ b/memo_js/test/tests.ts
@@ -242,49 +242,41 @@ suite("WorkTree", () => {
     const [set, createSetOp] = buffer1.addSelectionSet([
       { start: point(0, 0), end: point(0, 1) }
     ]);
-    assert.deepEqual(buffer1.getSelections(), {
-      local: { [set]: [{ start: point(0, 0), end: point(0, 1) }] },
-      remote: {}
+    assert.deepEqual(mapToObject(buffer1.getSelections().local), {
+      [set]: [{ start: point(0, 0), end: point(0, 1) }]
     });
+    assert.deepEqual(mapToObject(buffer1.getSelections().remote), {});
 
     await collectOps(tree2.applyOps([createSetOp.operation()]));
     assert.equal(selection2ChangeCount, 1);
-    assert.deepEqual(buffer2.getSelections(), {
-      local: {},
-      remote: {
-        [replica1]: [[{ start: point(0, 0), end: point(0, 1) }]]
-      }
+    assert.deepEqual(mapToObject(buffer2.getSelections().local), {});
+    assert.deepEqual(mapToObject(buffer2.getSelections().remote), {
+      [replica1]: [[{ start: point(0, 0), end: point(0, 1) }]]
     });
 
     const replaceSetOp = buffer1.replaceSelectionSet(set, [
       { start: point(0, 2), end: point(0, 3) }
     ]);
-    assert.deepEqual(buffer1.getSelections(), {
-      local: { [set]: [{ start: point(0, 2), end: point(0, 3) }] },
-      remote: {}
+    assert.deepEqual(mapToObject(buffer1.getSelections().local), {
+      [set]: [{ start: point(0, 2), end: point(0, 3) }]
     });
+    assert.deepEqual(mapToObject(buffer1.getSelections().remote), {});
 
     await collectOps(tree2.applyOps([replaceSetOp.operation()]));
     assert.equal(selection2ChangeCount, 2);
-    assert.deepEqual(buffer2.getSelections(), {
-      local: {},
-      remote: {
-        [replica1]: [[{ start: point(0, 2), end: point(0, 3) }]]
-      }
+    assert.deepEqual(mapToObject(buffer2.getSelections().local), {});
+    assert.deepEqual(mapToObject(buffer2.getSelections().remote), {
+      [replica1]: [[{ start: point(0, 2), end: point(0, 3) }]]
     });
 
     const removeSetOp = buffer1.removeSelectionSet(set);
-    assert.deepEqual(buffer1.getSelections(), {
-      local: {},
-      remote: {}
-    });
+    assert.deepEqual(mapToObject(buffer1.getSelections().local), {});
+    assert.deepEqual(mapToObject(buffer1.getSelections().remote), {});
 
     await collectOps(tree2.applyOps([removeSetOp.operation()]));
     assert.equal(selection2ChangeCount, 3);
-    assert.deepEqual(buffer2.getSelections(), {
-      local: {},
-      remote: {}
-    });
+    assert.deepEqual(mapToObject(buffer2.getSelections().local), {});
+    assert.deepEqual(mapToObject(buffer2.getSelections().remote), {});
   });
 
   test("an invalid base commit oid throws an error instead of crashing", async () => {
@@ -486,6 +478,14 @@ function parseEpochId(epochId: Uint8Array): ParsedEpochId {
   const timestamp = epochIdBuffer.readUInt32BE(1);
   const replicaId = uuidParse.unparse(epochIdBuffer.slice(8)) as ReplicaId;
   return { timestamp, replicaId };
+}
+
+function mapToObject<T>(map: Map<string | number, T>): { [key: string]: T } {
+  const object: { [key: string]: T } = {};
+  map.forEach((value, key) => {
+    object[key] = value;
+  });
+  return object;
 }
 
 class TestGitProvider implements GitProvider {


### PR DESCRIPTION
This pull request introduces new APIs for creating, replacing and removing selections. Examples can be found in the documentation or in tests:

* `Buffer.prototype.addSelectionSet(ranges)`. This method takes an array of ranges representing the initial selections of the set and returns a tuple containing the newly-created set id (that you can use to manipulate the set later on) and an operation that can be broadcasted to other replicas.
* `Buffer.prototype.replaceSelectionSet(setId, ranges)`. This method takes the id of a set that was previously created and an array of ranges to replace the existing ranges in the set. It returns an operation that can be broadcasted to other replicas.
* `Buffer.prototype.removeSelectionSet(setId)`. This method takes the id of a set that was previously created and deletes it. It return an operation that can be broadcasted to other replicas.
* `Buffer.prototype.getSelections()`. This method returns all the selections that are currently available on the Buffer in the following form:
  ```ts
  interface SelectionRanges {
    local: Map<SelectionSetId, Array<Range>>;
    remote: Map<ReplicaId, Array<Array<Range>>>;
  }
  ```
* `Buffer.prototype.onChange(listener)`. This method has been changed to also report all the selection ranges belonging to a buffer when operations are applied.