### PR TITLE
Introduce Location API

### DIFF
--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -211,7 +211,10 @@ impl Epoch {
         }
     }
 
-    pub fn buffer_selections_last_update(&self, file_id: FileId) -> Result<buffer::SelectionsVersion, Error> {
+    pub fn buffer_selections_last_update(
+        &self,
+        file_id: FileId,
+    ) -> Result<buffer::SelectionsVersion, Error> {
         if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
             Ok(buffer.selections_last_update)
         } else {

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -707,6 +707,12 @@ impl Epoch {
         })
     }
 
+    pub fn replica_location(&self, replica_id: ReplicaId) -> Option<FileId> {
+        self.replica_locations
+            .get(&replica_id)
+            .map(|location| location.file_id)
+    }
+
     pub fn replica_locations<'a>(&'a self) -> impl Iterator<Item = (ReplicaId, FileId)> + 'a {
         self.replica_locations
             .iter()

--- a/memo_core/src/epoch.rs
+++ b/memo_core/src/epoch.rs
@@ -211,7 +211,7 @@ impl Epoch {
         }
     }
 
-    pub fn buffer_selections_last_update(&self, file_id: FileId) -> Result<time::Lamport, Error> {
+    pub fn buffer_selections_last_update(&self, file_id: FileId) -> Result<buffer::SelectionsVersion, Error> {
         if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
             Ok(buffer.selections_last_update)
         } else {
@@ -964,7 +964,7 @@ impl Epoch {
     pub fn selections_changed_since(
         &self,
         file_id: FileId,
-        last_selection_update: time::Lamport,
+        last_selection_update: buffer::SelectionsVersion,
     ) -> Result<bool, Error> {
         if let Some(TextFile::Buffered(buffer)) = self.text_files.get(&file_id) {
             Ok(buffer.selections_changed_since(last_selection_update))

--- a/memo_core/src/serialization/schema.fbs
+++ b/memo_core/src/serialization/schema.fbs
@@ -92,7 +92,12 @@ table BufferOperation {
   lamport_timestamp:Timestamp;
 }
 
-union Operation { InsertMetadata, UpdateParent, BufferOperation }
+table UpdateActiveLocation {
+  file_id:FileId;
+  lamport_timestamp:Timestamp;
+}
+
+union Operation { InsertMetadata, UpdateParent, BufferOperation, UpdateActiveLocation }
 
 namespace worktree;
 

--- a/memo_core/src/serialization/schema_generated.rs
+++ b/memo_core/src/serialization/schema_generated.rs
@@ -1124,11 +1124,12 @@ pub enum Operation {
   InsertMetadata = 1,
   UpdateParent = 2,
   BufferOperation = 3,
+  UpdateActiveLocation = 4,
 
 }
 
 const ENUM_MIN_OPERATION: u8 = 0;
-const ENUM_MAX_OPERATION: u8 = 3;
+const ENUM_MAX_OPERATION: u8 = 4;
 
 impl<'a> flatbuffers::Follow<'a> for Operation {
   type Inner = Self;
@@ -1162,19 +1163,21 @@ impl flatbuffers::Push for Operation {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_OPERATION:[Operation; 4] = [
+const ENUM_VALUES_OPERATION:[Operation; 5] = [
   Operation::NONE,
   Operation::InsertMetadata,
   Operation::UpdateParent,
-  Operation::BufferOperation
+  Operation::BufferOperation,
+  Operation::UpdateActiveLocation
 ];
 
 #[allow(non_camel_case_types)]
-const ENUM_NAMES_OPERATION:[&'static str; 4] = [
+const ENUM_NAMES_OPERATION:[&'static str; 5] = [
     "NONE",
     "InsertMetadata",
     "UpdateParent",
-    "BufferOperation"
+    "BufferOperation",
+    "UpdateActiveLocation"
 ];
 
 pub fn enum_name_operation(e: Operation) -> &'static str {
@@ -1867,6 +1870,126 @@ impl<'a: 'b, 'b> BufferOperationBuilder<'a, 'b> {
   }
 }
 
+pub enum UpdateActiveLocationOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct UpdateActiveLocation<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for UpdateActiveLocation<'a> {
+    type Inner = UpdateActiveLocation<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> UpdateActiveLocation<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        UpdateActiveLocation {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args UpdateActiveLocationArgs<'args>) -> flatbuffers::WIPOffset<UpdateActiveLocation<'bldr>> {
+      let mut builder = UpdateActiveLocationBuilder::new(_fbb);
+      if let Some(x) = args.lamport_timestamp { builder.add_lamport_timestamp(x); }
+      if let Some(x) = args.file_id { builder.add_file_id(x); }
+      builder.add_file_id_type(args.file_id_type);
+      builder.finish()
+    }
+
+    pub const VT_FILE_ID_TYPE: flatbuffers::VOffsetT = 4;
+    pub const VT_FILE_ID: flatbuffers::VOffsetT = 6;
+    pub const VT_LAMPORT_TIMESTAMP: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub fn file_id_type(&self) -> FileId {
+    self._tab.get::<FileId>(UpdateActiveLocation::VT_FILE_ID_TYPE, Some(FileId::NONE)).unwrap()
+  }
+  #[inline]
+  pub fn file_id(&self) -> Option<flatbuffers::Table<'a>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(UpdateActiveLocation::VT_FILE_ID, None)
+  }
+  #[inline]
+  pub fn lamport_timestamp(&self) -> Option<&'a super::Timestamp> {
+    self._tab.get::<super::Timestamp>(UpdateActiveLocation::VT_LAMPORT_TIMESTAMP, None)
+  }
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn file_id_as_base_file_id(&'a self) -> Option<BaseFileId> {
+    if self.file_id_type() == FileId::BaseFileId {
+      self.file_id().map(|u| BaseFileId::init_from_table(u))
+    } else {
+      None
+    }
+  }
+
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn file_id_as_new_file_id(&'a self) -> Option<NewFileId> {
+    if self.file_id_type() == FileId::NewFileId {
+      self.file_id().map(|u| NewFileId::init_from_table(u))
+    } else {
+      None
+    }
+  }
+
+}
+
+pub struct UpdateActiveLocationArgs<'a> {
+    pub file_id_type: FileId,
+    pub file_id: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
+    pub lamport_timestamp: Option<&'a  super::Timestamp>,
+}
+impl<'a> Default for UpdateActiveLocationArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        UpdateActiveLocationArgs {
+            file_id_type: FileId::NONE,
+            file_id: None,
+            lamport_timestamp: None,
+        }
+    }
+}
+pub struct UpdateActiveLocationBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> UpdateActiveLocationBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_file_id_type(&mut self, file_id_type: FileId) {
+    self.fbb_.push_slot::<FileId>(UpdateActiveLocation::VT_FILE_ID_TYPE, file_id_type, FileId::NONE);
+  }
+  #[inline]
+  pub fn add_file_id(&mut self, file_id: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(UpdateActiveLocation::VT_FILE_ID, file_id);
+  }
+  #[inline]
+  pub fn add_lamport_timestamp(&mut self, lamport_timestamp: &'b  super::Timestamp) {
+    self.fbb_.push_slot_always::<&super::Timestamp>(UpdateActiveLocation::VT_LAMPORT_TIMESTAMP, lamport_timestamp);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> UpdateActiveLocationBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    UpdateActiveLocationBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<UpdateActiveLocation<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
 }  // pub mod epoch
 
 pub mod worktree {
@@ -2107,6 +2230,16 @@ impl<'a> EpochOperation<'a> {
   pub fn operation_as_buffer_operation(&'a self) -> Option<super::epoch::BufferOperation> {
     if self.operation_type() == super::epoch::Operation::BufferOperation {
       self.operation().map(|u| super::epoch::BufferOperation::init_from_table(u))
+    } else {
+      None
+    }
+  }
+
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn operation_as_update_active_location(&'a self) -> Option<super::epoch::UpdateActiveLocation> {
+    if self.operation_type() == super::epoch::Operation::UpdateActiveLocation {
+      self.operation().map(|u| super::epoch::UpdateActiveLocation::init_from_table(u))
     } else {
       None
     }

--- a/memo_core/src/work_tree.rs
+++ b/memo_core/src/work_tree.rs
@@ -1207,9 +1207,14 @@ mod tests {
             let mut network = Network::new();
             for i in 0..PEERS {
                 let observer = Rc::new(TestChangeObserver::new());
+                let commit = if rng.gen_weighted_bool(4) {
+                    *rng.choose(&commits).unwrap()
+                } else {
+                    *commits.last().unwrap()
+                };
                 let (tree, ops) = WorkTree::new(
                     Uuid::from_u128((i + 1) as u128),
-                    *rng.choose(&commits).unwrap(),
+                    commit,
                     None,
                     git.clone(),
                     Some(observer.clone()),

--- a/memo_js/README.md
+++ b/memo_js/README.md
@@ -167,6 +167,19 @@ buffer.onChange(change => {
 });
 ```
 
+## Changing the active location
+
+Optionally, you can also retrieve the location of other peers and transmit yours using the location API:
+
+```ts
+const operation = tree.setActiveLocation(buffer);
+broadcast([operation]);
+
+console.log(tree.getReplicaLocations()); /* => {
+  "65242244-9706-4b42-9785-fa5cbe5d5709": "foo/qux"
+}*/
+```
+
 ## Resetting to a different base commit
 
 If you want to reset the work tree to a different (possibly `null`) base (e.g. after a commit or a `git reset`), you can use the `reset` method:

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -154,10 +154,24 @@ export class WorkTree {
     }
     return buffer;
   }
+
+  setActiveLocation(buffer: Buffer | null): OperationEnvelope {
+    return this.tree.set_active_location(buffer ? buffer.id : null);
+  }
+
+  getReplicaLocations(): Map<ReplicaId, Path> {
+    const locations = this.tree.replica_locations();
+
+    const map = new Map<ReplicaId, Path>();
+    for (const replicaId in locations) {
+      map.set(replicaId as ReplicaId, locations[replicaId] as Path);
+    }
+    return map;
+  }
 }
 
 export class Buffer {
-  private id: BufferId;
+  id: BufferId;
   private tree: any;
   private observer: ChangeObserver;
 

--- a/memo_js/src/index.ts
+++ b/memo_js/src/index.ts
@@ -9,7 +9,7 @@ export {
   Range,
   ReplicaId,
   SelectionRanges,
-  SelectionSetId,
+  SelectionSetId
 } from "./support";
 import {
   BufferId,
@@ -194,7 +194,7 @@ export class Buffer {
 
   getSelectionRanges(): SelectionRanges {
     const selections = this.tree.selection_ranges(this.id);
-    return fromMemoSelectionRanges(selections)
+    return fromMemoSelectionRanges(selections);
   }
 
   onChange(callback: ChangeObserverCallback): Disposable {

--- a/memo_js/src/lib.rs
+++ b/memo_js/src/lib.rs
@@ -238,6 +238,18 @@ impl WorkTree {
         self.0.exists(&path)
     }
 
+    pub fn set_active_location(&self, buffer_id: JsValue) -> Result<OperationEnvelope, JsValue> {
+        let buffer_id = buffer_id.into_serde().map_err(|e| e.into_js_err())?;
+        self.0
+            .set_active_location(buffer_id)
+            .map(|operation| OperationEnvelope::new(operation))
+            .map_err(|e| e.into_js_err())
+    }
+
+    pub fn replica_locations(&self) -> JsValue {
+        JsValue::from_serde(&self.0.replica_locations()).unwrap()
+    }
+
     pub fn open_text_file(&mut self, path: String) -> js_sys::Promise {
         future_to_promise(
             self.0


### PR DESCRIPTION
This pull request introduces a first iteration of the location API. Specifically, `WorkTree` will now support the following methods:

* `setActiveLocation(buffer: Buffer | null)`, which can be used to transmit the location of the local replica.
* `getReplicaLocations`, which returns a `Map<ReplicaId, Path>` of the active path for every other replica that we have received a location operation for.

### Future steps

In the future I believe we should enhance this API to also supply a `SelectionSetId`. This is because any given buffer could have an arbitrary number of selections (e.g., when multiple editors are backed by the same buffer), and we want to provide a way of determining which one is the one currently used by each replica.

### A digression about paths

At some point I think we should do something about all these path-based APIs, as they prevent Memo from being used in contexts where untitled buffers can be created. Path-based APIs are nice in that they don't get invalidated when switching epochs, contrarily to `FileId`s which are tied only to a given epoch. I can think of different ways of solving this:

* Generate stable synthetic file identifiers in `WorkTree` that span across epochs; this would be similar to what we do with buffer ids, but wouldn't require opening a text file (and thus retrieve its base text) to use it in the API. This could potentially require a lot of tracking, though, even for files that are never opened.
* Don't try to hide the ephemerality of a `FileId` to clients, allowing them to decide what to do each time. Maybe these ids can literally include the epoch they belong to and memo could generate an error when trying to resolve one of them on a different epoch. We could still keep the path-based and buffer-based APIs, but we would return and accept `FileId`s in those contexts where it makes sense (such as the new location API proposed in this pull request).