### PR TITLE
CONTRIBUTING.md: change keyboard shortcut for open devtools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ That assumes you built with `--release`. To run the debug version, use `xray_deb
 XRAY_SRC_PATH=. script/xray_debug .
 ```
 
-Once a blank window has opened, press <kbd>cmd-t</kbd> to open the file selection menu. Search for a file, and press <kbd>enter</kbd> to open it. The contents of the file should appear in the window. If something does not go as expected, check the dev tools (<kbd>cmd-shift-i</kbd>) for errors.
+Once a blank window has opened, press <kbd>cmd-t</kbd> to open the file selection menu. Search for a file, and press <kbd>enter</kbd> to open it. The contents of the file should appear in the window. If something does not go as expected, check the dev tools (<kbd>alt-cmd-i</kbd>) for errors.
 
 ## Running tests and benchmarks
 


### PR DESCRIPTION
Keyboard shortcut was changed to `alt-cmd-i` instead of `cmd-shift-i`.

![Screen Shot 2562-04-18 at 10 37 57](https://user-images.githubusercontent.com/484530/56335552-2ba30180-61c7-11e9-9ce3-edeb86802e28.png)
